### PR TITLE
HSSFWorkbook: Use SHA1 in AddPicture when running under FIPS.

### DIFF
--- a/main/HSSF/UserModel/HSSFWorkbook.cs
+++ b/main/HSSF/UserModel/HSSFWorkbook.cs
@@ -1695,9 +1695,9 @@ namespace NPOI.HSSF.UserModel
             InitDrawings();
 
             byte[] uid;
-            using (MD5 md5 = MD5.Create())
+            using (SHA1 hasher = SHA1.Create())
             {
-                uid = md5.ComputeHash(pictureData);
+                uid = hasher.ComputeHash(pictureData);
             }
             EscherBitmapBlip blipRecord = new EscherBitmapBlip();
             blipRecord.RecordId = (short)(EscherBitmapBlip.RECORD_ID_START + format);


### PR DESCRIPTION
When Windows attempts to enforce FIPS, it disallows all usage of the MD5. Using SHA1 here will make it work.