### PR TITLE
Fix CopySheet()

### DIFF
--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -1881,7 +1881,7 @@ namespace NPOI.HSSF.UserModel
             if (null == agg || null == agg.GetEscherContainer())
             {
                 int pos = _sheet.AggregateDrawingRecords(dm, false);
-                if (-1 == pos)
+                if (-1 == pos || (agg = (EscherAggregate)_sheet.Records[(pos)]) == null || agg.GetEscherContainer() == null)
                 {
                     if (createIfMissing)
                     {
@@ -1896,7 +1896,6 @@ namespace NPOI.HSSF.UserModel
                         return null;
                     }
                 }
-                agg = (EscherAggregate)_sheet.Records[(pos)];
             }
             return new HSSFPatriarch(this, agg);
         }

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -1878,7 +1878,7 @@ namespace NPOI.HSSF.UserModel
                 }
             }
             EscherAggregate agg = (EscherAggregate)_sheet.FindFirstRecordBySid(EscherAggregate.sid);
-            if (null == agg)
+            if (null == agg || null == agg.GetEscherContainer())
             {
                 int pos = _sheet.AggregateDrawingRecords(dm, false);
                 if (-1 == pos)

--- a/ooxml/XSSF/UserModel/XSSFCellStyle.cs
+++ b/ooxml/XSSF/UserModel/XSSFCellStyle.cs
@@ -1344,9 +1344,9 @@ namespace NPOI.XSSF.UserModel
                 if (ct.diagonalDown == true && ct.diagonalUp == true)
                     return BorderDiagonal.Both;
                 else if (ct.diagonalDown == true)
-                    return BorderDiagonal.Forward;
-                else if (ct.diagonalUp == true)
                     return BorderDiagonal.Backward;
+                else if (ct.diagonalUp == true)
+                    return BorderDiagonal.Forward;
                 else
                     return BorderDiagonal.None;
             }
@@ -1362,17 +1362,17 @@ namespace NPOI.XSSF.UserModel
                 }
                 else if (value == BorderDiagonal.Forward)
                 {
-                    ct.diagonalDown = true;
-                    ct.diagonalDownSpecified = true;
-                    ct.diagonalUp = false;
-                    ct.diagonalUpSpecified = false;
-                }
-                else if (value == BorderDiagonal.Backward)
-                {
                     ct.diagonalDown = false;
                     ct.diagonalDownSpecified = false;
                     ct.diagonalUp = true;
                     ct.diagonalUpSpecified = true;
+                }
+                else if (value == BorderDiagonal.Backward)
+                {
+                    ct.diagonalDown = true;
+                    ct.diagonalDownSpecified = true;
+                    ct.diagonalUp = false;
+                    ct.diagonalUpSpecified = false;
                 }
                 else
                 {

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -211,7 +211,10 @@ namespace NPOI.XSSF.UserModel
                         hyperRel = hyperRels.GetRelationshipByID(hyperlink.id);
                     }
 
-                    hyperlinks.Add(new XSSFHyperlink(hyperlink, hyperRel));
+                    if (hyperRel != null)
+                    {
+                        hyperlinks.Add(new XSSFHyperlink(hyperlink, hyperRel));
+                    }
                 }
             }
             catch (InvalidFormatException e)
@@ -4026,11 +4029,6 @@ namespace NPOI.XSSF.UserModel
                 logger.Log(POILogger.WARN, "Cloning sheets with comments is not yet supported.");
                 ct.UnsetLegacyDrawing();
             }
-            if (ct.IsSetPageSetup())
-            {
-                logger.Log(POILogger.WARN, "Cloning sheets with page setup is not yet supported.");
-                ct.UnsetPageSetup();
-            }
             newSheet.IsSelected = false;
 
             // copy sheet's relations
@@ -4050,6 +4048,10 @@ namespace NPOI.XSSF.UserModel
                     rel.TargetUri, (TargetMode)rel.TargetMode, rel.RelationshipType);
                 newSheet.AddRelation(rel.Id, r);
             }
+            
+            // copy hyperlinks
+            newSheet.hyperlinks = new List<XSSFHyperlink>(hyperlinks);
+            
             // clone the sheet drawing along with its relationships
             if (dg != null)
             {


### PR DESCRIPTION
1. Copying the PageSetup works flawlessly, which is why that block can be removed. With that block, I always get the NotImplementedException, so an Exception which has no benefit.
2. The XSSFHyperlink collection needs to be copied. Otherwise, the links are not displayed in the duplicated sheet but Excel throws a parsing error upon opening the workbook.
3. When hyperRel is null, it is better to cancel adding this hyperlink than canceling the whole process. With the addition of point 2., the links are shown anyway.