### PR TITLE
Push Environment.Username out of internal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ e. Designed to be interface-oriented (take a look at NPOI.SS namespace)<br />
 f. Support not only export but also import<br />
 g. .Net 2.0 based even for xlsx and docx (though we also support .NET 4.0)<br />
 h. Real successful cases all over the world<br />
-i. huge amout of basic examples
+i. huge amount of basic examples
 
 NPOI on SNS
 ============
@@ -31,4 +31,4 @@ System Requirement
 ===================
 VS2010 with .NET 4.0 runtime<br />
 VS2005 or VS2008 with .NET 2.0 Runtime (SP1) <br />
-vs2003 with .NET 1.1 (Obselete, last version is 1.2.1. No further support)<br />
+VS2003 with .NET 1.1 (Obsolete, last version is 1.2.1. No further support)<br />

--- a/main/HSSF/UserModel/HSSFWorkbook.cs
+++ b/main/HSSF/UserModel/HSSFWorkbook.cs
@@ -168,9 +168,15 @@ namespace NPOI.HSSF.UserModel
         /// Creates new HSSFWorkbook from scratch (start here!)
         /// </summary>
         public HSSFWorkbook()
-            : this(InternalWorkbook.CreateWorkbook())
+            : this(Environment.UserName)
         {
 
+        }
+
+        public HSSFWorkbook(string username)
+            : this(InternalWorkbook.CreateWorkbook(username))
+        {
+            
         }
 
         public HSSFWorkbook(InternalWorkbook book)


### PR DESCRIPTION
Allow the username to be passed in rather than using Environment.Username. Allows unit test results to be identical when run by different users.

Also, fix a couple of minor typos.
