### PR TITLE
Add missing files to vs2010 projects to fix build

### DIFF
--- a/main/main vs10.csproj
+++ b/main/main vs10.csproj
@@ -197,10 +197,13 @@
     <Compile Include="SS\Formula\Atp\NetworkdaysFunction.cs" />
     <Compile Include="SS\Formula\Atp\WorkdayCalculator.cs" />
     <Compile Include="SS\Formula\Atp\WorkdayFunction.cs" />
+    <Compile Include="SS\Formula\Functions\Code.cs" />
+    <Compile Include="SS\Formula\Functions\Complex.cs" />
     <Compile Include="SS\Formula\Functions\Errortype.cs" />
     <Compile Include="SS\Formula\Functions\Hyperlink.cs" />
     <Compile Include="SS\Formula\Functions\Rank.cs" />
     <Compile Include="SS\Formula\Functions\Rate.cs" />
+    <Compile Include="SS\Formula\Functions\Rept.cs" />
     <Compile Include="SS\Formula\Functions\Sumifs.cs" />
     <Compile Include="SS\Formula\Functions\WeekdayFunc.cs" />
     <Compile Include="SS\HtmlDocumentFacade.cs" />

--- a/ooxml/OpenXmlFormats/OpenXmlFormats vs2010.csproj
+++ b/ooxml/OpenXmlFormats/OpenXmlFormats vs2010.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NPOI.OpenXmlFormats</RootNamespace>
     <AssemblyName>NPOI.OpenXmlFormats</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>


### PR DESCRIPTION
The build is currently broken for the vs2010 solution. New files were committed and used without adding the files to the appropriate projects. Additionally, one of the projects was changed from .NET 4.0 to .NET 2.0 even though it is referencing other .NET 4.0 projects.