### PR TITLE
Fix XLSX default vertical alignment

### DIFF
--- a/main/main vs10.csproj
+++ b/main/main vs10.csproj
@@ -197,10 +197,13 @@
     <Compile Include="SS\Formula\Atp\NetworkdaysFunction.cs" />
     <Compile Include="SS\Formula\Atp\WorkdayCalculator.cs" />
     <Compile Include="SS\Formula\Atp\WorkdayFunction.cs" />
+    <Compile Include="SS\Formula\Functions\Code.cs" />
+    <Compile Include="SS\Formula\Functions\Complex.cs" />
     <Compile Include="SS\Formula\Functions\Errortype.cs" />
     <Compile Include="SS\Formula\Functions\Hyperlink.cs" />
     <Compile Include="SS\Formula\Functions\Rank.cs" />
     <Compile Include="SS\Formula\Functions\Rate.cs" />
+    <Compile Include="SS\Formula\Functions\Rept.cs" />
     <Compile Include="SS\Formula\Functions\Sumifs.cs" />
     <Compile Include="SS\Formula\Functions\WeekdayFunc.cs" />
     <Compile Include="SS\HtmlDocumentFacade.cs" />

--- a/ooxml/OpenXmlFormats/OpenXmlFormats vs2010.csproj
+++ b/ooxml/OpenXmlFormats/OpenXmlFormats vs2010.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NPOI.OpenXmlFormats</RootNamespace>
     <AssemblyName>NPOI.OpenXmlFormats</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_CellAlignment.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_CellAlignment.cs
@@ -39,7 +39,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private bool horizontalFieldSpecified;
 
-        private ST_VerticalAlignment verticalField= ST_VerticalAlignment.center;
+        private ST_VerticalAlignment verticalField = ST_VerticalAlignment.bottom;
 
         private bool verticalFieldSpecified;
 
@@ -79,8 +79,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 ctObj.horizontal = (ST_HorizontalAlignment)Enum.Parse(typeof(ST_HorizontalAlignment), node.Attributes["horizontal"].Value);
             if (node.Attributes["vertical"] != null)
                 ctObj.vertical = (ST_VerticalAlignment)Enum.Parse(typeof(ST_VerticalAlignment), node.Attributes["vertical"].Value);
-            else
-                ctObj.vertical = ST_VerticalAlignment.center;
             ctObj.textRotation = XmlHelper.ReadLong(node.Attributes["textRotation"]);
             ctObj.wrapText = XmlHelper.ReadBool(node.Attributes["wrapText"]);
             ctObj.indent = XmlHelper.ReadLong(node.Attributes["indent"]);
@@ -96,9 +94,10 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            if(this.horizontal!= ST_HorizontalAlignment.general)
+            if(this.horizontal != ST_HorizontalAlignment.general)
                 XmlHelper.WriteAttribute(sw, "horizontal", this.horizontal.ToString());
-            XmlHelper.WriteAttribute(sw, "vertical", this.vertical.ToString());
+            if (this.vertical != ST_VerticalAlignment.bottom)
+                XmlHelper.WriteAttribute(sw, "vertical", this.vertical.ToString());
             XmlHelper.WriteAttribute(sw, "textRotation", this.textRotation);
             if(this.wrapText)
                 XmlHelper.WriteAttribute(sw, "wrapText", this.wrapText);
@@ -148,7 +147,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
         [XmlAttribute]
-        [DefaultValue(ST_VerticalAlignment.top)]
+        [DefaultValue(ST_VerticalAlignment.bottom)]
         public ST_VerticalAlignment vertical
         {
             get


### PR DESCRIPTION
The default vertical alignment in Excel for XLSX files is bottom, not center. Additionally, this value is never written to styles.xml by Excel (Even when the user manually selects it).

Default cell format:
![image](https://cloud.githubusercontent.com/assets/715687/5740040/727b2820-9bc5-11e4-941e-342c2ff3f2e1.png)

    <cellXfs count="1">
        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
    </cellXfs>

Manually set Vertical=Bottom and Horizontal=Left:

![image](https://cloud.githubusercontent.com/assets/715687/5740167/7e57344e-9bc6-11e4-99fe-7357573c8d54.png)

    <cellXfs count="2">
        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1">
            <alignment horizontal="left"/>
        </xf>
    </cellXfs>
