### PR TITLE
Fix phonetic guides reading/writing issue

### DIFF
--- a/ooxml/OOXML.csproj
+++ b/ooxml/OOXML.csproj
@@ -222,14 +222,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="npoi.snk" />
-<ItemGroup>
-	<None Include="..\main\npoi.snk">
-	      <Link>npoi.snk</Link>
-	 </None>
+    <None Include="..\main\npoi.snk">
+      <Link>npoi.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/ooxml/OpenXmlFormats/Spreadsheet/SharedStringTable.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/SharedStringTable.cs
@@ -99,9 +99,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_PhoneticRun ctObj = new CT_PhoneticRun();
-            ctObj.t = XmlHelper.ReadString(node.Attributes["t"]);
             ctObj.sb = XmlHelper.ReadUInt(node.Attributes["sb"]);
             ctObj.eb = XmlHelper.ReadUInt(node.Attributes["eb"]);
+
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                if (childNode.LocalName == "t")
+                    ctObj.t = childNode.InnerText;
+            }
             return ctObj;
         }
 
@@ -110,10 +115,16 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "t", this.t);
-            XmlHelper.WriteAttribute(sw, "sb", this.sb);
-            XmlHelper.WriteAttribute(sw, "eb", this.eb);
-            sw.Write("/>");
+            XmlHelper.WriteAttribute(sw, "sb", this.sb.ToString(), true);
+            XmlHelper.WriteAttribute(sw, "eb", this.eb.ToString(), true);
+            sw.Write(">");
+            sw.Write("<t>");
+            if (this.t != null)
+            {
+                sw.Write(XmlHelper.EncodeXml(this.t));
+            }
+            sw.Write("</t>");
+            sw.Write(string.Format("</{0}>", nodeName));
         }
 
     }


### PR DESCRIPTION
This will fix OOXML `CT_PhoneticRun` handling.

## Issue

NPOI may break xlsx files that contain phonetic guides (furigana) information.
I do `(new XSSFWorkbook(fileWithFurigana)).Write(output)`, and then open the `output` file in Excel, Excel says:

> Excel found unreadable content in output.xlsx. Do you want to recover the contents of this workbook? If you trust the source of this workbook, click Yes.

If _Yes_ is selected, the file can be opened but its content becomes empty.
