### PR TITLE
Fixing weird XSSF CellStyle Border behaviour..

### DIFF
--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_Border.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_Border.cs
@@ -128,12 +128,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public CT_Border Copy()
         {
             CT_Border obj = new CT_Border();
-            obj.bottomField = this.bottomField;
-            obj.topField = this.topField;
-            obj.rightField = this.rightField;
-            obj.leftField = this.leftField;
-            obj.horizontalField = this.horizontalField;
-            obj.verticalField = this.verticalField;
+            obj.bottomField = this.bottomField == null ? null : this.bottomField.Copy();
+            obj.topField = this.topField == null ? null : this.topField.Copy();
+            obj.rightField = this.rightField == null ? null : this.rightField.Copy();
+            obj.leftField = this.leftField == null ? null : this.leftField.Copy();
+
+            obj.diagonalField = this.diagonalField == null ? null : this.diagonalField.Copy();
+            obj.verticalField = this.verticalField == null ? null : this.verticalField.Copy();
+            obj.horizontalField = this.horizontalField == null ? null : this.horizontalField.Copy();
+
+            obj.diagonalUpField = this.diagonalUpField;
+            obj.diagonalUpFieldSpecified = this.diagonalUpFieldSpecified;
+            obj.diagonalDownField = this.diagonalDownField;
+            obj.diagonalDownFieldSpecified = this.diagonalDownFieldSpecified;
             obj.outlineField = this.outlineField;
             return obj;
         }

--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_BorderPr.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_BorderPr.cs
@@ -100,5 +100,13 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 this.styleField = value;
             }
         }
+
+        public CT_BorderPr Copy()
+        {
+            var res = new CT_BorderPr();
+            res.colorField = this.colorField == null ? null : this.colorField.Copy();
+            res.style = this.style;
+            return res;
+        }
     }
 }

--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_Colors.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_Colors.cs
@@ -372,8 +372,21 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write("/>");
         }
 
+        public CT_Color Copy()
+        {
+            var res = new CT_Color();
+            res.autoField = this.autoField;
 
+            res.indexedField = this.indexedField;
 
+            res.rgbField = this.rgbField == null ? null : (byte[])this.rgbField.Clone(); // type ST_UnsignedIntHex is xsd:hexBinary restricted to length 4 (octets!? - see http://www.grokdoc.net/index.php/EOOXML_Objections_Clearinghouse)
+
+            res.themeField = this.themeField; // TODO change all the uses theme to use uint instead of signed integer variants
+
+            res.tintField = this.tintField;
+
+            return res;
+        }
     }
 
 }

--- a/ooxml/XSSF/UserModel/XSSFCellStyle.cs
+++ b/ooxml/XSSF/UserModel/XSSFCellStyle.cs
@@ -1034,7 +1034,7 @@ namespace NPOI.XSSF.UserModel
                 int idx = (int)_cellXf.borderId;
                 XSSFCellBorder cf = _stylesSource.GetBorderAt(idx);
 
-                ctBorder = (CT_Border)cf.GetCTBorder();
+                ctBorder = (CT_Border)cf.GetCTBorder().Copy();
             }
             else
             {


### PR DESCRIPTION
XSSF border style caching is returning a reference to the original CT_Border object when modifying a cellstyle border property. This can result in a previous CT_Border being reused and then modified (without user being aware or being able to avoid), producing incorrect results.

Example to reproduce (In an ASP.net):
```
            var book = new XSSFWorkbook();

            var sheet = book.CreateSheet("Sheet1");
            
            var row = sheet.CreateRow(1);

            {
                var cell = row.CreateCell(1);

                var cellStyle = book.CreateCellStyle();
                cellStyle.BorderTop = NPOI.SS.UserModel.BorderStyle.Thin;

                cell.CellStyle = cellStyle;
            }

            {
                var cell = row.CreateCell(2);

                var cellStyle = book.CreateCellStyle();
                cellStyle.BorderTop = NPOI.SS.UserModel.BorderStyle.Thin;
                cellStyle.BorderRight = NPOI.SS.UserModel.BorderStyle.Thin;

                cell.CellStyle = cellStyle;
            }

            book.Write(this.Response.OutputStream);
            this.Response.ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
            this.Response.End();
```

This is what happens before the patch, the border from the second cell is being applied to both first and second cell.
![before](https://cloud.githubusercontent.com/assets/11416577/9866724/465ebdca-5ba9-11e5-9b32-3a64d815eba5.png)

And now its correct, yay:
![after](https://cloud.githubusercontent.com/assets/11416577/9866725/47ac5822-5ba9-11e5-90ac-c3c674bf7f94.png)






