### PR TITLE
Valid underline type 'none' value is 0. The library writes u element …

### DIFF
--- a/main/SS/UserModel/FontUnderline.cs
+++ b/main/SS/UserModel/FontUnderline.cs
@@ -56,7 +56,7 @@ namespace NPOI.SS.UserModel
         /**
          * No underline.
          */
-        public static readonly FontUnderline NONE = new FontUnderline(5);
+        public static readonly FontUnderline NONE = new FontUnderline(0);
 
 
         private int value;
@@ -112,12 +112,12 @@ namespace NPOI.SS.UserModel
         {
             if (_table == null)
             {
-                _table = new FontUnderline[6];
+                _table = new FontUnderline[5];
+                _table[0] = FontUnderline.NONE;
                 _table[1] = FontUnderline.SINGLE;
                 _table[2] = FontUnderline.DOUBLE;
                 _table[3] = FontUnderline.SINGLE_ACCOUNTING;
                 _table[4] = FontUnderline.DOUBLE_ACCOUNTING;
-                _table[5] = FontUnderline.NONE;
             }
         }
         public static FontUnderline ValueOf(int value)

--- a/ooxml/XSSF/UserModel/XSSFFont.cs
+++ b/ooxml/XSSF/UserModel/XSSFFont.cs
@@ -528,7 +528,7 @@ namespace NPOI.XSSF.UserModel
          */
         internal void SetUnderline(FontUnderlineType underline)
         {
-            if (underline == FontUnderlineType.None && _ctFont.sizeOfUArray() > 0)
+            if (underline == FontUnderlineType.None)
             {
                 _ctFont.SetUArray(null);
             }


### PR DESCRIPTION
…with "none" value.(<u val="none"/>)

But the library writes invalid value 5.(<u val="5"/>)

And we don't need "u" element when underline type is 'none'.
Currently the library writes u element when user specifies 'none' value odd times.