### PR TITLE
Set fullPrecision default to true as it is for a new Excel file

### DIFF
--- a/ooxml/OpenXmlFormats/Spreadsheet/Workbook.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Workbook.cs
@@ -324,7 +324,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.iterate = XmlHelper.ReadBool(node.Attributes["iterate"]);
             ctObj.iterateCount = XmlHelper.ReadUInt(node.Attributes["iterateCount"]);
             ctObj.iterateDelta = XmlHelper.ReadDouble(node.Attributes["iterateDelta"]);
-            ctObj.fullPrecision = XmlHelper.ReadBool(node.Attributes["fullPrecision"]);
+            ctObj.fullPrecision = XmlHelper.ReadBool(node.Attributes["fullPrecision"], true);
             ctObj.calcCompleted = XmlHelper.ReadBool(node.Attributes["calcCompleted"]);
             ctObj.calcOnSave = XmlHelper.ReadBool(node.Attributes["calcOnSave"]);
             ctObj.concurrentCalc = XmlHelper.ReadBool(node.Attributes["concurrentCalc"]);


### PR DESCRIPTION
The problem is describben here by someone else:
http://npoi.codeplex.com/discussions/647190

So this just impacts if you are using an already existing Excel file to start with.

If you create a new Excel file fullPrecision is always true, but the property is not set in the workbook.xml file. So when we read the template and the property is not there the default value is then set to false, but in my opinion it should be true to be consistent with creating a new Excel file.

