### PR TITLE
CT_Shapetype defaults fixed to fix cell comments

### DIFF
--- a/ooxml/OpenXmlFormats/Vml/Main.cs
+++ b/ooxml/OpenXmlFormats/Vml/Main.cs
@@ -3688,8 +3688,8 @@ namespace NPOI.OpenXmlFormats.Vml
         
         private string adjField;
         private string idField;
-        private ST_TrueFalse filledField;
-        private ST_TrueFalse strokedField;
+        private ST_TrueFalse filledField = ST_TrueFalse.t;
+        private ST_TrueFalse strokedField = ST_TrueFalse.t;
         private ST_TrueFalse preferrelativeField;
         //private string styleField;
         private float sptField;

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFVMLDrawing.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFVMLDrawing.cs
@@ -134,5 +134,61 @@ namespace NPOI.XSSF.UserModel
             Assert.IsNull(vml.FindCommentShape(0, 0));
 
         }
+        [Test]
+        public void TestCommentShowsBox()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            wb.CreateSheet();
+            XSSFSheet sheet = (XSSFSheet)wb.GetSheetAt(0);
+            XSSFCell cell = (XSSFCell)sheet.CreateRow(0).CreateCell(0);
+            XSSFDrawing drawing = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFCreationHelper factory = (XSSFCreationHelper)wb.GetCreationHelper();
+            XSSFClientAnchor anchor = (XSSFClientAnchor)factory.CreateClientAnchor();
+            anchor.Col1 = cell.ColumnIndex;
+            anchor.Col2 = cell.ColumnIndex + 3;
+            anchor.Row1 = cell.RowIndex;
+            anchor.Row2 = cell.RowIndex + 5;
+            XSSFComment comment = (XSSFComment)drawing.CreateCellComment(anchor);
+            XSSFRichTextString str = (XSSFRichTextString)factory.CreateRichTextString("this is a comment");
+            comment.String = str;
+            cell.CellComment = comment;
+
+            XSSFVMLDrawing vml = sheet.GetVMLDrawing(false);
+            CT_Shapetype shapetype = null;
+            ArrayList items = vml.GetItems();
+            foreach (object o in items)
+                if (o is CT_Shapetype)
+                    shapetype = (CT_Shapetype)o;
+            Assert.AreEqual(NPOI.OpenXmlFormats.Vml.ST_TrueFalse.t, shapetype.stroked);
+            Assert.AreEqual(NPOI.OpenXmlFormats.Vml.ST_TrueFalse.t, shapetype.filled);
+
+            using (MemoryStream ws = new MemoryStream())
+            {
+                wb.Write(ws);
+
+                using (MemoryStream rs = new MemoryStream(ws.GetBuffer()))
+                {
+                    wb = new XSSFWorkbook(rs);
+                    sheet = (XSSFSheet)wb.GetSheetAt(0);
+
+                    vml = sheet.GetVMLDrawing(false);
+                    shapetype = null;
+                    items = vml.GetItems();
+                    foreach (object o in items)
+                        if (o is CT_Shapetype)
+                            shapetype = (CT_Shapetype)o;
+
+                    //wb.Write(new FileStream("comments.xlsx", FileMode.Create));
+                    //using (MemoryStream ws2 = new MemoryStream())
+                    //{
+                    //    vml.Write(ws2);
+                    //    throw new System.Exception(System.Text.Encoding.UTF8.GetString(ws2.GetBuffer()));
+                    //}
+
+                    Assert.AreEqual(NPOI.OpenXmlFormats.Vml.ST_TrueFalse.t, shapetype.stroked);
+                    Assert.AreEqual(NPOI.OpenXmlFormats.Vml.ST_TrueFalse.t, shapetype.filled);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Original symptom: Comments in *.xlsx files had no background color and were difficult to read.

It looks like there's a problem reading/writing CT_Shapetype .filled and .stroked fields.  This occurs because CT_Shapetype.Write() defaults .stroked and .filled values to true, but the CT_Shapetype class defaults these values to false.

I've updated the CT_Shapetype class to default these two values to true.  

This fixed the original symptom by removing filled="false" and stroked="false" in the shapetype tag corresponding to comments in the *.xlsx file at: "xl\drawings\vmlDrawing1.vml".  This un-hid the square background box that OOXML was trying to draw behind comments.  