### PR TITLE
Bundle NUnit Test Adapter into projects via NuGet.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Lib/
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
+packages/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/testcases/main/NPOI.TestCases.csproj
+++ b/testcases/main/NPOI.TestCases.csproj
@@ -91,8 +91,24 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\solution\Lib\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\solution\Lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -324,6 +340,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="npoi.snk" />
+    <None Include="packages.config" />
     <None Include="POIFS\Data\excel_with_embeded.xls" />
     <None Include="POIFS\Data\ppt_with_embeded.ppt" />
     <None Include="POIFS\Data\ShortLastBlock.qwp" />

--- a/testcases/main/SS/UserModel/BaseTestConditionalFormatting.cs
+++ b/testcases/main/SS/UserModel/BaseTestConditionalFormatting.cs
@@ -668,13 +668,13 @@ namespace TestCases.SS.UserModel
             Assert.AreEqual(HSSFColor.Blue.Index, patternFmt.FillForegroundColor);
 
             Assert.AreEqual((short)FillPattern.NoFill, patternFmt.FillPattern);
-            patternFmt.FillPattern = (short)FillPattern.SolidForeground;
+            patternFmt.FillPattern = FillPattern.SolidForeground;
             Assert.AreEqual((short)FillPattern.SolidForeground, patternFmt.FillPattern);
             patternFmt.FillPattern = (short)FillPattern.NoFill;
             Assert.AreEqual((short)FillPattern.NoFill, patternFmt.FillPattern);
             if (this._testDataProvider.GetSpreadsheetVersion() == SpreadsheetVersion.EXCEL97)
             {
-                patternFmt.FillPattern = (short)FillPattern.Bricks;
+                patternFmt.FillPattern = FillPattern.Bricks;
                 Assert.AreEqual((short)FillPattern.Bricks, patternFmt.FillPattern);
             }
 

--- a/testcases/main/packages.config
+++ b/testcases/main/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net40" />
+</packages>

--- a/testcases/ooxml/NPOI.OOXML.TestCases.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.csproj
@@ -79,9 +79,25 @@
       <HintPath>..\..\solution\Lib\Release.net4\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\solution\Lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -228,6 +244,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/testcases/ooxml/packages.config
+++ b/testcases/ooxml/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net40" />
+</packages>

--- a/testcases/openxml4net/NPOI.OOXML4Net.Testcases.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.Testcases.csproj
@@ -74,9 +74,25 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\..\solution\Lib\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.0.12051, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\solution\Lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\..\solution\visualstudio\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -104,6 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">

--- a/testcases/openxml4net/packages.config
+++ b/testcases/openxml4net/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
This changes allows us to executing unit tests on Visual Studio Test Explorer **without installing any extensions** such as NUnit test runner extension for Visual Studio.

Anybody who using Visual Studio 2012 or above can execute unit tests immediately after only `git clone`.

This feature helps committers to executing unit tests with any changes/commits, because there are no need to preparing - such as installing some Visual Studio extensions - for executing unit tests.