### PR TITLE
Fix: Temporary files remain when ZipPackage closed.

### DIFF
--- a/ooxml/openxml4Net/OPC/ZipPackage.cs
+++ b/ooxml/openxml4Net/OPC/ZipPackage.cs
@@ -343,7 +343,7 @@ namespace NPOI.OpenXml4Net.OPC
                     {
                         // Either the save operation succeed or not, we delete the
                         // temporary file
-                        File.Delete(tempfilePath);
+                        File.Delete(fi.FullName);
                         
                             logger
                                     .Log(POILogger.WARN, "The temporary file: '"

--- a/solution/Lib/RunSerialyAndSweepTmpFilesAttribute.cs
+++ b/solution/Lib/RunSerialyAndSweepTmpFilesAttribute.cs
@@ -1,0 +1,51 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using System;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+namespace TestCases
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+    public sealed class RunSerialyAndSweepTmpFilesAttribute : Attribute, ITestAction
+    {
+        private static object syncSequential = new object();
+
+        public ActionTargets Targets { get { return ActionTargets.Test; } }
+
+        public void BeforeTest(TestDetails testDetails)
+        {
+            Monitor.Enter(syncSequential);
+            SweepTemporaryFiles();
+        }
+
+        public void AfterTest(TestDetails testDetails)
+        {
+            SweepTemporaryFiles();
+            Monitor.Exit(syncSequential);
+        }
+
+        private static void SweepTemporaryFiles()
+        {
+            foreach (var tempFilePath in Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp"))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+    }
+}

--- a/testcases/ooxml/NPOI.OOXML.TestCases.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.csproj
@@ -109,6 +109,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\solution\Lib\RunSerialyAndSweepTmpFilesAttribute.cs">
+      <Link>RunSerialyAndSweepTmpFilesAttribute.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFBugs.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFBugs.cs
@@ -2556,7 +2556,7 @@ namespace NPOI.XSSF.UserModel
          *  32,767 must not be -32,768, then -32,767, -32,766
          *  long time test, run over 1 minute.
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         public void Bug57880()
         {
             Console.WriteLine("long time test, run over 1 minute.");
@@ -2603,6 +2603,8 @@ namespace NPOI.XSSF.UserModel
 
             wb.Close();
             tmp.Delete();
+
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
 
     }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -31,6 +31,7 @@ using System;
 using TestCases.SS.UserModel;
 using System.Text;
 using NPOI.SS.Util;
+using TestCases;
 namespace NPOI.XSSF.UserModel
 {
 
@@ -47,7 +48,7 @@ namespace NPOI.XSSF.UserModel
         /**
          * Tests that we can save, and then re-load a new document
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         public void SaveLoadNew()
         {
             XSSFWorkbook workbook = new XSSFWorkbook();
@@ -116,6 +117,8 @@ namespace NPOI.XSSF.UserModel
             Assert.AreEqual("hello world", sheet1.GetRow(1).GetCell(0).RichStringCellValue.String);
 
             pkg.Close();
+
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
         [Test]
         public void Existing()

--- a/testcases/openxml4net/NPOI.OOXML4Net.Testcases.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.Testcases.csproj
@@ -100,6 +100,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\solution\Lib\RunSerialyAndSweepTmpFilesAttribute.cs">
+      <Link>RunSerialyAndSweepTmpFilesAttribute.cs</Link>
+    </Compile>
     <Compile Include="OPC\Compliance\TestOPCComplianceCoreProperties.cs" />
     <Compile Include="OPC\Compliance\TestOPCCompliancePackageModel.cs" />
     <Compile Include="OPC\Compliance\TestOPCCompliancePartName.cs" />

--- a/testcases/openxml4net/OPC/Compliance/TestOPCComplianceCoreProperties.cs
+++ b/testcases/openxml4net/OPC/Compliance/TestOPCComplianceCoreProperties.cs
@@ -287,7 +287,7 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
          * Document with no core properties - testing at the OPC level,
          *  from a temp-file, saving in-place
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         public void TestNoCoreProperties_saveInPlace()
         {
             String sampleFileName = "OPCCompliance_NoCoreProperties.xlsx";
@@ -325,6 +325,8 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
             // Finish and tidy
             pkg.Revert();
             tmp.Delete();
+
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
 
     }

--- a/testcases/openxml4net/TestPackage.cs
+++ b/testcases/openxml4net/TestPackage.cs
@@ -151,7 +151,7 @@ namespace TestCases.OPC
          *  document and another part, save and re-load and
          *  have everything Setup as expected
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         //[Ignore("add relation Uri #Sheet1!A1")]
         public void TestCreatePackageWithCoreDocument()
         {
@@ -236,6 +236,7 @@ namespace TestCases.OPC
                 pkg.Close();
             }
 
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
 
         private void assertMSCompatibility(OPCPackage pkg)
@@ -260,7 +261,7 @@ namespace TestCases.OPC
         /**
          * Test namespace opening.
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         public void TestOpenPackage()
         {
             FileInfo targetFile = OpenXml4NetTestDataSamples.GetOutputFile("TestOpenPackageTMP.docx");
@@ -321,6 +322,8 @@ namespace TestCases.OPC
 
             ZipFileAssert.AssertEqual(expectedFile, targetFile);
             File.Delete(targetFile.FullName);
+
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
 
         /**
@@ -507,7 +510,7 @@ namespace TestCases.OPC
          * Test that we can open a file by path, and then
          *  write Changes to it.
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         public void TestOpenFileThenOverWrite()
         {
             string tempFile = TempFile.GetTempFilePath("poiTesting", "tmp");
@@ -543,12 +546,14 @@ namespace TestCases.OPC
             p = OPCPackage.Open(tempFile, PackageAccess.READ);
             p.Close();
             File.Delete(tempFile);
+
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
         /**
          * Test that we can open a file by path, save it
          *  to another file, then delete both
          */
-        [Test]
+        [Test, RunSerialyAndSweepTmpFiles]
         public void TestOpenFileThenSaveDelete()
         {
             string tempFile = TempFile.GetTempFilePath("poiTesting", "tmp");
@@ -566,6 +571,8 @@ namespace TestCases.OPC
             // Delete both the files
             File.Delete(tempFile);
             File.Delete(tempFile2);
+
+            Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
 
         private static ContentTypeManager GetContentTypeManager(OPCPackage pkg)


### PR DESCRIPTION
### How to reprodue the bug:

We can reproduce the bug by simple code that only open and close .xlsx file like this:

```csharp
var baseDir = AppDomain.CurrentDomain.BaseDirectory;
var path = Path.Combine(baseDir, "Book1.xlsx");
var book = WorkbookFactory.Create(path);
book.Close();
```

After `book.Close()` method was invoked, temporary file ("OpenXml4Net~.tmp") was created and remain even after program exited.

![image](https://cloud.githubusercontent.com/assets/95908/22738612/7c873a7c-ee4b-11e6-8e89-e0761a7d2be9.png)

### How to fix the bug:

#### 1. Wrote test code

At first, I wrote improving unit test code to detect temporary files remain or not. (commit 		0c512ad )

This change effect 7 test cases from "passed" to "failed".

You can get those 7 test cases from ".playlist" file below:

Download: ["The bug that temporary files remain.playlit.zip"](https://github.com/tonyqus/npoi/files/760650/The.bug.that.temporary.files.remain.playlit.zip)

#### 2. Fix the bug and confirmed the test cases are all green.

Next step, I fixed "ZipPackage.cs". ( commit 2537b8f )

Original source code was try to delete temporary file of invalid path like "OpenXml4Net1234" - it has no directory name, random number suffix, and ".tmp" file name extension  -.

It should be apply complete full path like "**C:\Foo\Bar\\** OpenXml4Net1234**9.tmp**".

After this change, I confirmed the 7 test cases are all green 😃 