### PR TITLE
Word processing fields issue

### DIFF
--- a/ooxml/OpenXmlFormats/Wordprocessing/FormField.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/FormField.cs
@@ -639,15 +639,15 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
         {
             sw.Write(string.Format("<w:{0}>", nodeName));
             if (this.defaultField != null)
-                this.defaultField.Write(sw, "w:default");
+                this.defaultField.Write(sw, "default");
             if (this.checkedField != null)
-                this.checkedField.Write(sw, "w:checked");
+                this.checkedField.Write(sw, "checked");
             if (this.itemField != null)
             {
                 if (this.itemField is CT_OnOff)
-                    (this.itemField as CT_OnOff).Write(sw, "w:sizeAuto");
+                    (this.itemField as CT_OnOff).Write(sw, "sizeAuto");
                 else
-                    (this.itemField as CT_HpsMeasure).Write(sw, "w:size");
+                    (this.itemField as CT_HpsMeasure).Write(sw, "size");
             }
             sw.Write(string.Format("</w:{0}>", nodeName));
         }
@@ -742,12 +742,12 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
         {
             sw.Write(string.Format("<w:{0}>", nodeName));
             if (this.defaultField != null)
-                this.defaultField.Write(sw, "w:default");
+                this.defaultField.Write(sw, "default");
             if (this.resultField != null)
-                this.resultField.Write(sw, "w:result");
+                this.resultField.Write(sw, "result");
             foreach (CT_String str in listEntry)
             {
-                str.Write(sw, "w:listEntry");
+                str.Write(sw, "listEntry");
             }
             sw.Write(string.Format("</w:{0}>", nodeName));
         }

--- a/ooxml/OpenXmlFormats/Wordprocessing/FormField.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/FormField.cs
@@ -358,7 +358,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 //}
                 else if (childNode.LocalName == "enabled")
                 {
-                    ctObj.AddNewObject(CT_OnOff.Parse(childNode, namespaceManager), FFDataItemsType.name);
+                    ctObj.AddNewObject(CT_OnOff.Parse(childNode, namespaceManager), FFDataItemsType.enabled);
                 }
                 else if (childNode.LocalName == "calcOnExit")
                 {
@@ -397,7 +397,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
         }
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<w:{0}", nodeName));
+            sw.Write(string.Format("<w:{0}>", nodeName));
 
             for (int i=0;i<this.itemsElementNameField.Count;i++)
             {
@@ -423,7 +423,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     (this.itemsField[i] as CT_FFTextInput).Write(sw, "textInput");
             }
 
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write(string.Format("</w:{0}>", nodeName));
         }
         private void AddNewObject(object obj, FFDataItemsType type)
         {
@@ -1031,17 +1031,17 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<w:{0}", nodeName));
+            sw.Write(string.Format("<w:{0}>", nodeName));
             if (this.typeField == null)
-                this.typeField.Write(sw, "w:type");
+                this.typeField.Write(sw, "type");
             if (this.defaultField != null)
-                this.defaultField.Write(sw, "w:default");
+                this.defaultField.Write(sw, "default");
             if (this.formatField != null)
-                this.formatField.Write(sw, "w:format");
+                this.formatField.Write(sw, "format");
             if (this.maxLengthField != null)
-                this.maxLengthField.Write(sw, "w:maxLength");
+                this.maxLengthField.Write(sw, "maxLength");
             
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write(string.Format("</w:kp{0}>", nodeName));
         }
     }
 

--- a/ooxml/OpenXmlFormats/Wordprocessing/FormField.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/FormField.cs
@@ -1041,7 +1041,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             if (this.maxLengthField != null)
                 this.maxLengthField.Write(sw, "maxLength");
             
-            sw.Write(string.Format("</w:kp{0}>", nodeName));
+            sw.Write(string.Format("</w:{0}>", nodeName));
         }
     }
 

--- a/ooxml/OpenXmlFormats/Wordprocessing/HdrFtr.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/HdrFtr.cs
@@ -670,13 +670,13 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             sw.Write(">");
             if (this.pos != null)
-                this.pos.Write(sw, "w:pos");
+                this.pos.Write(sw, "pos");
             if (this.numFmt != null)
-                this.numFmt.Write(sw, "w:numFmt");
+                this.numFmt.Write(sw, "numFmt");
             if (this.numStart != null)
-                this.numStart.Write(sw, "w:numStart");
+                this.numStart.Write(sw, "numStart");
             if (this.numRestart != null)
-                this.numRestart.Write(sw, "w:numRestart");
+                this.numRestart.Write(sw, "numRestart");
             sw.Write(string.Format("</w:{0}>", nodeName));
         }
 
@@ -1649,13 +1649,13 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             sw.Write(">");
             if (this.pos != null)
-                this.pos.Write(sw, "w:pos");
+                this.pos.Write(sw, "pos");
             if (this.numFmt != null)
-                this.numFmt.Write(sw, "w:numFmt");
+                this.numFmt.Write(sw, "numFmt");
             if (this.numStart != null)
-                this.numStart.Write(sw, "w:numStart");
+                this.numStart.Write(sw, "numStart");
             if (this.numRestart != null)
-                this.numRestart.Write(sw, "w:numRestart");
+                this.numRestart.Write(sw, "numRestart");
             sw.Write(string.Format("</w:{0}>", nodeName));
         }
 

--- a/ooxml/OpenXmlFormats/Wordprocessing/Paragraph.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/Paragraph.cs
@@ -2068,43 +2068,43 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:rsidSect", this.rsidSect);
             sw.Write(">");
             if (this.footnotePr != null)
-                this.footnotePr.Write(sw, "w:footnotePr");
+                this.footnotePr.Write(sw, "footnotePr");
             if (this.endnotePr != null)
-                this.endnotePr.Write(sw, "w:endnotePr");
+                this.endnotePr.Write(sw, "endnotePr");
             if (this.type != null)
-                this.type.Write(sw, "w:type");
+                this.type.Write(sw, "type");
             if (this.pgSz != null)
-                this.pgSz.Write(sw, "w:pgSz");
+                this.pgSz.Write(sw, "pgSz");
             if (this.pgMar != null)
-                this.pgMar.Write(sw, "w:pgMar");
+                this.pgMar.Write(sw, "pgMar");
             if (this.paperSrc != null)
-                this.paperSrc.Write(sw, "w:paperSrc");
+                this.paperSrc.Write(sw, "paperSrc");
             if (this.pgBorders != null)
-                this.pgBorders.Write(sw, "w:pgBorders");
+                this.pgBorders.Write(sw, "pgBorders");
             if (this.lnNumType != null)
-                this.lnNumType.Write(sw, "w:lnNumType");
+                this.lnNumType.Write(sw, "lnNumType");
             if (this.pgNumType != null)
-                this.pgNumType.Write(sw, "w:pgNumType");
+                this.pgNumType.Write(sw, "pgNumType");
             if (this.cols != null)
-                this.cols.Write(sw, "w:cols");
+                this.cols.Write(sw, "cols");
             if (this.formProt != null)
-                this.formProt.Write(sw, "w:formProt");
+                this.formProt.Write(sw, "formProt");
             if (this.vAlign != null)
-                this.vAlign.Write(sw, "w:vAlign");
+                this.vAlign.Write(sw, "vAlign");
             if (this.noEndnote != null)
-                this.noEndnote.Write(sw, "w:noEndnote");
+                this.noEndnote.Write(sw, "noEndnote");
             if (this.titlePg != null)
-                this.titlePg.Write(sw, "w:titlePg");
+                this.titlePg.Write(sw, "titlePg");
             if (this.textDirection != null)
-                this.textDirection.Write(sw, "w:textDirection");
+                this.textDirection.Write(sw, "textDirection");
             if (this.bidi != null)
-                this.bidi.Write(sw, "w:bidi");
+                this.bidi.Write(sw, "bidi");
             if (this.rtlGutter != null)
-                this.rtlGutter.Write(sw, "w:rtlGutter");
+                this.rtlGutter.Write(sw, "rtlGutter");
             if (this.docGrid != null)
-                this.docGrid.Write(sw, "w:docGrid");
+                this.docGrid.Write(sw, "docGrid");
             if (this.printerSettings != null)
-                this.printerSettings.Write(sw, "w:printerSettings");
+                this.printerSettings.Write(sw, "printerSettings");
             sw.Write(string.Format("</w:{0}>", nodeName));
         }
 
@@ -6690,7 +6690,7 @@ cnfStyleField == null;
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             sw.Write(">");
             if (this.rPr != null)
-                this.rPr.Write(sw, "w:rPr");
+                this.rPr.Write(sw, "rPr");
             sw.Write(string.Format("</w:{0}>", nodeName));
         }
 

--- a/ooxml/OpenXmlFormats/Wordprocessing/Paragraph.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/Paragraph.cs
@@ -3292,7 +3292,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:beforeLines", this.beforeLines);
             if(this.beforeAutospacing!= ST_OnOff.off)
                 XmlHelper.WriteAttribute(sw, "w:beforeAutospacing", this.beforeAutospacing.ToString());
-            XmlHelper.WriteAttribute(sw, "w:after", this.after);
+            XmlHelper.WriteAttribute(sw, "w:after", this.after, true);
             XmlHelper.WriteAttribute(sw, "w:afterLines", this.afterLines);
             if (this.afterAutospacing != ST_OnOff.off)
                 XmlHelper.WriteAttribute(sw, "w:afterAutospacing", this.afterAutospacing.ToString());

--- a/ooxml/OpenXmlFormats/Wordprocessing/Run.cs
+++ b/ooxml/OpenXmlFormats/Wordprocessing/Run.cs
@@ -553,7 +553,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Br)
                     ((CT_Br)o).Write(sw, "br");
                 else if (o is CT_Markup)
-                    ((CT_Markup)o).Write(sw, "w:commentReference");
+                    ((CT_Markup)o).Write(sw, "commentReference");
                 else if (o is CT_Empty && this.ItemsElementName[i] == RunItemsChoiceType.continuationSeparator)
                     sw.Write("<w:continuationSeparator/>");
                 else if (o is CT_Empty && this.ItemsElementName[i] == RunItemsChoiceType.cr)


### PR DESCRIPTION
Found that while saving a word document (docx) NPOI make some exception. 
This was due to fields feature. Some XML tags that was wrongly formated and a bad type for enabled parameter.

Then when fixed, found also that there was some issu with the layout. It was missing to write the attribute 'after' event if value equals to 0.