### PR TITLE
Fix: MathX.Round() - fixing some instances of incorrect rounding and addin…

### DIFF
--- a/main/SS/Formula/Functions/MathX.cs
+++ b/main/SS/Formula/Functions/MathX.cs
@@ -66,20 +66,12 @@ namespace NPOI.SS.Formula.Functions
             {
                 if (p >= 0)
                 {
-                    int temp = (int)Math.Pow(10, p);
-                    double delta = 0.5;
-                    int x = p + 1;
-                    while (x > 0)
-                    {
-                        delta = delta / 10;
-                        x--;
-                    }
-                    retval = (double)(Math.Round((decimal)(n + delta) * temp) / temp);
+                    retval = (double)Math.Round((decimal)n, p, MidpointRounding.AwayFromZero);
                 }
                 else
                 {
                     int temp = (int)Math.Pow(10, Math.Abs(p));
-                    retval = (double)(Math.Round((decimal)(n) / temp) * temp);
+                    retval = (double)(Math.Round((decimal)(n) / temp, MidpointRounding.AwayFromZero) * temp);
                 }
             }
 

--- a/testcases/main/SS/Formula/Functions/TestMathX.cs
+++ b/testcases/main/SS/Formula/Functions/TestMathX.cs
@@ -735,6 +735,9 @@ namespace TestCases.SS.Formula.Functions
 
             d = Double.MinValue; p = 1;
             AssertEquals("round ", 0.0d, MathX.Round(d, p));
+
+            d = 481.75478; p = 2;
+            AssertEquals("round ", 481.75d, MathX.Round(d, p));
         }
         [Test]
         public void TestRoundDown()


### PR DESCRIPTION
During a project a while ago I found an edge case a while ago whereby the MathX.Round() function wasn't matching the output of Excel.  At the time I downloaded the NPOI source, made a fix and incorporated it into the project.  I've since realised I should have created a PR for it (which is what this is!).  I posted the change on Stackoverflow here: https://stackoverflow.com/questions/41467799/npoi-round-formula/41961253#41961253

In summary - the value 481.75478 should round to 481.75, however, it was rounding to 481.76

I have:

* run the "TestRound()" test function and saw it pass
* added the above case to the list of scenarios in "TestRound()" and saw it fail
* added my fix and saw "TestRound()" pass again

