### PR TITLE
Fix: AutoFilter colId is required even when 0

### DIFF
--- a/ooxml/OpenXmlFormats/Spreadsheet/AutoFilter.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/AutoFilter.cs
@@ -218,7 +218,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "colId", this.colId);
+            XmlHelper.WriteAttribute(sw, "colId", this.colId, true);
             XmlHelper.WriteAttribute(sw, "hiddenButton", this.hiddenButton);
             XmlHelper.WriteAttribute(sw, "showButton", this.showButton);
             sw.Write(">");

--- a/ooxml/openxml4Net/Util/XmlHelper.cs
+++ b/ooxml/openxml4Net/Util/XmlHelper.cs
@@ -345,9 +345,9 @@ namespace NPOI.OpenXml4Net.Util
 
             WriteAttribute(sw, attributeName, BitConverter.ToString(value).Replace("-", ""), false);
         }
-        public static void WriteAttribute(StreamWriter sw, string attributeName, uint value)
+        public static void WriteAttribute(StreamWriter sw, string attributeName, uint value, bool writeIfBlank = false)
         {
-            WriteAttribute(sw, attributeName, (int)value, false);
+            WriteAttribute(sw, attributeName, (int)value, writeIfBlank);
         }
 
         public static void WriteAttribute(StreamWriter sw, string attributeName, DateTime? value)


### PR DESCRIPTION
Fixed issues with writing Table AutoFilters to XML. Excel 2013 will not read a file where the autoFilter colId is not specified. NPOI was not writing this when the colId was 0. 

Below is an example file where I was having the issue. Just creating a XSSFWorkbook from a stream and writing it back out produces this error (see attached).
[MikaelTest.xlsx](https://github.com/tonyqus/npoi/files/1648149/MikaelTest.xlsx)

I'm not entirely sure how to write a unit test for this since the method I changed writes to a StreamWriter. Any tips here?