### PR TITLE
Add DateAxis for category axis. Add support for drawing bar chart. Fix a bug that XSSFChartAxis property IsVisible is opposite to its real value. Fix a bug that "AddPicture to Word" failed. Support line and bar mixed chart. Add set color for XSSFBarChartData and XSSFLineChartData. Add set MajorTickMark for Axis and add set DispBlanksAs for XSSFChart.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ x64/
 [Oo]bj/
 Lib/
 packages/
+# Visual Studio 2015 cache/options directory
+.vs/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
@@ -22,6 +24,7 @@ packages/
 
 *_i.c
 *_p.c
+*_i.h
 *.ilk
 *.meta
 *.obj
@@ -48,9 +51,11 @@ packages/
 ipch/
 *.aps
 *.ncb
+*.opendb
 *.opensdf
 *.sdf
 *.cachefile
+*.VC.db
 
 # Visual Studio profiler
 *.psess

--- a/main/NPOI.csproj
+++ b/main/NPOI.csproj
@@ -676,6 +676,8 @@
     <Compile Include="SS\Formula\SharedFormula.cs" />
     <Compile Include="SS\UserModel\BorderDiagonal.cs" />
     <Compile Include="SS\UserModel\Charts\AxisTickMark.cs" />
+    <Compile Include="SS\UserModel\Charts\BarChartData.cs" />
+    <Compile Include="SS\UserModel\Charts\BarChartSeries.cs" />
     <Compile Include="SS\UserModel\Charts\ChartDataSource.cs" />
     <Compile Include="SS\UserModel\Charts\ChartSeries.cs" />
     <Compile Include="SS\UserModel\Charts\DataSources.cs" />

--- a/main/SS/UserModel/Charts/BarChartData.cs
+++ b/main/SS/UserModel/Charts/BarChartData.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NPOI.SS.UserModel.Charts
+{
+    /// <summary>
+    /// Data for a Bar Chart
+    /// </summary>
+    /// <typeparam name="Tx"></typeparam>
+    /// <typeparam name="Ty"></typeparam>
+    public interface IBarChartData<Tx, Ty> : IChartData
+    {
+
+        IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categories, IChartDataSource<Ty> values);
+
+        /**
+         * @return list of all series.
+         */
+        List<IBarChartSeries<Tx, Ty>> GetSeries();
+    }
+}

--- a/main/SS/UserModel/Charts/BarChartSeries.cs
+++ b/main/SS/UserModel/Charts/BarChartSeries.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NPOI.SS.UserModel.Charts
+{
+    public interface IBarChartSeries<Tx, Ty> : IChartSeries
+    {
+        /**
+         * @return data source used for category axis data.
+         */
+        IChartDataSource<Tx> GetCategoryAxisData();
+
+        /**
+         * @return data source used for value axis.
+         */
+        IChartDataSource<Ty> GetValues();
+    }
+}

--- a/main/SS/UserModel/Charts/ChartAxisFactory.cs
+++ b/main/SS/UserModel/Charts/ChartAxisFactory.cs
@@ -31,6 +31,8 @@ namespace NPOI.SS.UserModel.Charts
         IValueAxis CreateValueAxis(AxisPosition pos);
 
         IChartAxis CreateCategoryAxis(AxisPosition pos);
+
+        IChartAxis CreateDateAxis(AxisPosition pos);
     }
 
 }

--- a/main/SS/UserModel/Charts/ChartDataFactory.cs
+++ b/main/SS/UserModel/Charts/ChartDataFactory.cs
@@ -31,6 +31,7 @@ namespace NPOI.SS.UserModel.Charts
         /// <returns></returns>
         IScatterChartData<Tx, Ty> CreateScatterChartData<Tx, Ty>();
         ILineChartData<Tx, Ty> CreateLineChartData<Tx, Ty>();
+        IBarChartData<Tx, Ty> CreateBarChartData<Tx, Ty>();
     }
 
 }

--- a/ooxml/NPOI.OOXML.csproj
+++ b/ooxml/NPOI.OOXML.csproj
@@ -153,6 +153,7 @@
     <Compile Include="XSSF\Streaming\Values\StringValue.cs" />
     <Compile Include="XSSF\Streaming\Values\Value.cs" />
     <Compile Include="XSSF\UserModel\Charts\AbstractXSSFChartSeries.cs" />
+    <Compile Include="XSSF\UserModel\Charts\XSSFBarChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFCategoryAxis.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFChartAxis.cs">
       <SubType>Code</SubType>

--- a/ooxml/NPOI.OOXML.csproj
+++ b/ooxml/NPOI.OOXML.csproj
@@ -164,6 +164,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="XSSF\UserModel\Charts\XSSFChartUtil.cs" />
+    <Compile Include="XSSF\UserModel\Charts\XSSFDateAxis.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFLineChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFManualLayout.cs">
       <SubType>Code</SubType>

--- a/ooxml/OpenXmlFormats/Drawing/Chart/AreaChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/AreaChart.cs
@@ -106,6 +106,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement(Order = 0)]
         public CT_Grouping grouping
@@ -601,6 +605,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement(Order = 0)]
         public CT_Grouping grouping

--- a/ooxml/OpenXmlFormats/Drawing/Chart/BarChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/BarChart.cs
@@ -126,6 +126,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement(Order = 0)]
         public CT_BarDir barDir
@@ -811,6 +815,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             this.varyColorsField = new CT_Boolean();
             this.groupingField = new CT_BarGrouping();
             this.barDirField = new CT_BarDir();
+        }
+
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
         }
 
         [XmlElement(Order = 0)]

--- a/ooxml/OpenXmlFormats/Drawing/Chart/BarChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/BarChart.cs
@@ -257,6 +257,43 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.extLstField = value;
             }
         }
+
+        public CT_BarGrouping AddNewGrouping()
+        {
+            this.groupingField = new CT_BarGrouping();
+            return this.groupingField;
+        }
+        public CT_BarSer AddNewSer()
+        {
+            CT_BarSer newSer = new CT_BarSer();
+            if (this.serField == null)
+            {
+                this.serField = new List<CT_BarSer>();
+            }
+            this.serField.Add(newSer);
+            return newSer;
+        }
+
+        public CT_Boolean AddNewVaryColors()
+        {
+            this.varyColorsField = new CT_Boolean();
+            return this.varyColorsField;
+        }
+
+        public CT_UnsignedInt AddNewAxId()
+        {
+            CT_UnsignedInt si = new CT_UnsignedInt();
+            if (this.axIdField == null)
+                this.axIdField = new List<CT_UnsignedInt>();
+            axIdField.Add(si);
+            return si;
+        }
+
+        public CT_BarDir AddNewBarDir()
+        {
+            this.barDirField = new CT_BarDir();
+            return this.barDirField;
+        }
     }
 
 
@@ -706,6 +743,30 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             {
                 this.extLstField = value;
             }
+        }
+
+        public CT_UnsignedInt AddNewIdx()
+        {
+            this.idxField = new CT_UnsignedInt();
+            return this.idxField;
+        }
+
+        public CT_UnsignedInt AddNewOrder()
+        {
+            this.orderField = new CT_UnsignedInt();
+            return this.orderField;
+        }
+
+        public CT_AxDataSource AddNewCat()
+        {
+            this.catField = new CT_AxDataSource();
+            return this.catField;
+        }
+
+        public CT_NumDataSource AddNewVal()
+        {
+            this.valField = new CT_NumDataSource();
+            return this.valField;
         }
     }
 

--- a/ooxml/OpenXmlFormats/Drawing/Chart/BubbleChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/BubbleChart.cs
@@ -544,6 +544,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
+
         [XmlElement(Order = 0)]
         public CT_Boolean varyColors
         {

--- a/ooxml/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -14,6 +14,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
     using System.ComponentModel;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Xml;
     using NPOI.OpenXml4Net.Util;
     using System.Text;
@@ -9579,6 +9580,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             }
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
+
         [XmlElement("ser", Order = 1)]
         public List<CT_SurfaceSer> ser
         {
@@ -10348,6 +10354,27 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             this.scatterChartField.Add(newobj);
             return newobj;
         }
+
+        public int GetAllSeriesCount()
+        {
+            return (surfaceChartField == null ? 0 : surfaceChartField.Select(x=>x.GetSeriesCount()).Sum())
+                + (lineChartField == null ? 0 : lineChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (bubbleChartField == null ? 0 : bubbleChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (bar3DChartField == null ? 0 : bar3DChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (area3DChartField == null ? 0 : area3DChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (doughnutChartField == null ? 0 : doughnutChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (pie3DChartField == null ? 0 : pie3DChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (line3DChartField == null ? 0 : line3DChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (surface3DChartField == null ? 0 : surface3DChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (barChartField == null ? 0 : barChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (radarChartField == null ? 0 : radarChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (areaChartField == null ? 0 : areaChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (scatterChartField == null ? 0 : scatterChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (ofPieChartField == null ? 0 : ofPieChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (pieChartField == null ? 0 : pieChartField.Select(x => x.GetSeriesCount()).Sum())
+                + (stockChartField == null ? 0 : stockChartField.Select(x => x.GetSeriesCount()).Sum());
+        }
+
         List<CT_SurfaceChart> surfaceChartField;
         public List<CT_SurfaceChart> surfaceChart
         {

--- a/ooxml/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -10549,6 +10549,17 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             }
         }
 
+        public CT_BarChart AddNewBarChart()
+        {
+            CT_BarChart ctchart = new CT_BarChart();
+            if (this.barChartField == null)
+            {
+                this.barChartField = new List<CT_BarChart>();
+            }
+            this.barChartField.Add(ctchart);
+            return ctchart;
+        }
+
         public CT_LineChart AddNewLineChart()
         {
             CT_LineChart ctchart = new CT_LineChart();

--- a/ooxml/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -4218,7 +4218,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
 
         private CT_UnsignedInt crossAxField;
 
-        private object itemField;
+        //private object itemField;
 
         private CT_Boolean autoField;
 
@@ -4275,8 +4275,8 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                     ctObj.txPr = CT_TextBody.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "crossAx")
                     ctObj.crossAx = CT_UnsignedInt.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "Item")
-                    ctObj.Item = new Object();
+                else if (childNode.LocalName == "crosses")
+                    ctObj.crosses = CT_Crosses.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "auto")
                     ctObj.auto = CT_Boolean.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "lblOffset")
@@ -4331,8 +4331,8 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.txPr.Write(sw, "txPr");
             if (this.crossAx != null)
                 this.crossAx.Write(sw, "crossAx");
-            if (this.Item != null)
-                sw.Write("<Item/>");
+            if (this.crosses != null)
+                this.crosses.Write(sw, "crosses");
             if (this.auto != null)
                 this.auto.Write(sw, "auto");
             if (this.lblOffset != null)
@@ -4540,18 +4540,20 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             }
         }
 
-        [XmlElement("crosses", typeof(CT_Crosses), Order = 14)]
-        [XmlElement("crossesAt", typeof(CT_Double), Order = 14)]
-        public object Item
+        CT_Double crossesAtField;
+        [XmlElement(Order = 14)]
+        public CT_Double crossesAt
         {
-            get
-            {
-                return this.itemField;
-            }
-            set
-            {
-                this.itemField = value;
-            }
+            get { return this.crossesAtField; }
+            set { this.crossesAtField = value; }
+        }
+
+        CT_Crosses crossesField;
+        [XmlElement(Order = 14)]
+        public CT_Crosses crosses
+        {
+            get { return this.crossesField; }
+            set { this.crossesField = value; }
         }
 
         [XmlElement(Order = 15)]
@@ -4656,6 +4658,71 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             {
                 this.extLstField = value;
             }
+        }
+
+        public CT_NumFmt AddNewNumFmt()
+        {
+            this.numFmtField = new CT_NumFmt();
+            return numFmtField;
+        }
+
+        public bool IsSetNumFmt()
+        {
+            return this.numFmtField != null;
+        }
+
+        public CT_UnsignedInt AddNewAxId()
+        {
+            this.axIdField = new CT_UnsignedInt();
+            return this.axIdField;
+        }
+
+        public CT_AxPos AddNewAxPos()
+        {
+            this.axPosField = new CT_AxPos();
+            return this.axPosField;
+        }
+
+        public CT_Scaling AddNewScaling()
+        {
+            this.scalingField = new CT_Scaling();
+            return this.scalingField;
+        }
+
+        public CT_Crosses AddNewCrosses()
+        {
+            this.crossesField = new CT_Crosses();
+            return this.crossesField;
+        }
+
+        public CT_UnsignedInt AddNewCrossAx()
+        {
+            this.crossAxField = new CT_UnsignedInt();
+            return this.crossAxField;
+        }
+
+        public CT_TickLblPos AddNewTickLblPos()
+        {
+            this.tickLblPosField = new CT_TickLblPos();
+            return this.tickLblPosField;
+        }
+
+        public CT_Boolean AddNewDelete()
+        {
+            this.deleteField = new CT_Boolean();
+            return this.deleteField;
+        }
+
+        public CT_TickMark AddNewMajorTickMark()
+        {
+            this.majorTickMarkField = new CT_TickMark();
+            return this.majorTickMarkField;
+        }
+
+        public CT_TickMark AddNewMinorTickMark()
+        {
+            this.minorTickMarkField = new CT_TickMark();
+            return this.minorTickMarkField;
         }
     }
 
@@ -10497,6 +10564,17 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             if(this.catAxField==null)
                 this.catAxField = new List<CT_CatAx>();
             this.catAxField.Add(newax);
+            return newax;
+        }
+
+        public CT_DateAx AddNewDateAx()
+        {
+            CT_DateAx newax = new CT_DateAx();
+            if (this.dateAxField == null)
+            {
+                this.dateAxField = new List<CT_DateAx>();
+            }
+            this.dateAxField.Add(newax);
             return newax;
         }
     }

--- a/ooxml/OpenXmlFormats/Drawing/Chart/LineChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/LineChart.cs
@@ -374,6 +374,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             //this.groupingField = new CT_Grouping();
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
+
         [XmlElement(Order = 0)]
         public CT_Grouping grouping
         {
@@ -807,6 +812,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement("ser", Order = 0)]
         public List<CT_LineSer> ser
@@ -1016,6 +1025,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement(Order = 0)]
         public CT_Grouping grouping

--- a/ooxml/OpenXmlFormats/Drawing/Chart/PieChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/PieChart.cs
@@ -78,6 +78,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement(Order = 0)]
         public CT_Boolean varyColors
@@ -204,6 +208,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 }
             }
             sw.Write(string.Format("</c:{0}>", nodeName));
+        }
+
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
         }
 
         [XmlElement(Order = 0)]
@@ -690,6 +699,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
+
         [XmlElement(Order = 0)]
         public CT_Boolean varyColors
         {
@@ -953,6 +967,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 }
             }
             sw.Write(string.Format("</c:{0}>", nodeName));
+        }
+
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
         }
 
         [XmlElement(Order = 0)]

--- a/ooxml/OpenXmlFormats/Drawing/Chart/RadarChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/RadarChart.cs
@@ -397,6 +397,10 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
 
         [XmlElement(Order = 0)]
         public CT_RadarStyle radarStyle

--- a/ooxml/OpenXmlFormats/Drawing/Chart/ScatterChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/ScatterChart.cs
@@ -524,6 +524,12 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             this.serField.Add(ser);
             return ser;
         }
+
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
+
         [XmlElement(Order = 0)]
         public CT_ScatterStyle scatterStyle
         {

--- a/ooxml/OpenXmlFormats/Drawing/Chart/SurfaceChart.cs
+++ b/ooxml/OpenXmlFormats/Drawing/Chart/SurfaceChart.cs
@@ -213,6 +213,11 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 
+        public int GetSeriesCount()
+        {
+            return this.serField == null ? 0 : this.serField.Count;
+        }
+
         [XmlElement(Order = 0)]
         public CT_Boolean wireframe
         {

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -40,6 +40,16 @@ namespace NPOI.XSSF.UserModel.Charts
                 this.values = values;
             }
 
+            public void SetId(int id)
+            {
+                this.id = id;
+            }
+
+            public void SetOrder(int order)
+            {
+                this.order = order;
+            }
+
             public IChartDataSource<Tx> GetCategoryAxisData()
             {
                 return categories;
@@ -99,11 +109,15 @@ namespace NPOI.XSSF.UserModel.Charts
 
             XSSFChart xssfChart = (XSSFChart)chart;
             CT_PlotArea plotArea = xssfChart.GetCTChart().plotArea;
+            int allSeriesCount = plotArea.GetAllSeriesCount();
             CT_BarChart barChart = plotArea.AddNewBarChart();
             barChart.AddNewVaryColors().val = 0;
 
-            foreach (Series s in series)
+            for (int i = 0; i < series.Count; ++i)
             {
+                Series s = (Series)series[i];
+                s.SetId(allSeriesCount + i);
+                s.SetOrder(allSeriesCount + i);
                 s.AddToChart(barChart);
             }
 

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -78,6 +78,9 @@ namespace NPOI.XSSF.UserModel.Charts
                 ctGrouping.val = ST_BarGrouping.clustered;
                 ctBarSer.AddNewIdx().val = (uint)id;
                 ctBarSer.AddNewOrder().val = (uint)order;
+                CT_Boolean ctNoInvertIfNegative = new CT_Boolean();
+                ctNoInvertIfNegative.val = 0;
+                ctBarSer.invertIfNegative = ctNoInvertIfNegative;
 
                 CT_BarDir ctBarDir = ctBarChart.AddNewBarDir();
                 ctBarDir.val = ST_BarDir.col;

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -1,7 +1,9 @@
-﻿using NPOI.OpenXmlFormats.Dml.Chart;
+﻿using NPOI.OpenXmlFormats.Dml;
+using NPOI.OpenXmlFormats.Dml.Chart;
 using NPOI.SS.UserModel.Charts;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 
 namespace NPOI.XSSF.UserModel.Charts
@@ -27,6 +29,7 @@ namespace NPOI.XSSF.UserModel.Charts
         {
             private int id;
             private int order;
+            private byte[] fillColor;
             private IChartDataSource<Tx> categories;
             private IChartDataSource<Ty> values;
 
@@ -48,6 +51,14 @@ namespace NPOI.XSSF.UserModel.Charts
             public void SetOrder(int order)
             {
                 this.order = order;
+            }
+
+            public void SetFillColor(Color color)
+            {
+                fillColor = new byte[3];
+                fillColor[0] = color.R;
+                fillColor[1] = color.G;
+                fillColor[2] = color.B;
             }
 
             public IChartDataSource<Tx> GetCategoryAxisData()
@@ -79,6 +90,14 @@ namespace NPOI.XSSF.UserModel.Charts
                 if (IsTitleSet)
                 {
                     ctBarSer.tx = GetCTSerTx();
+                }
+
+                if (fillColor != null)
+                {
+                    ctBarSer.spPr = new OpenXmlFormats.Dml.Chart.CT_ShapeProperties();
+                    CT_SolidColorFillProperties ctSolidColorFillProperties = ctBarSer.spPr.AddNewSolidFill();
+                    CT_SRgbColor ctSRgbColor = ctSolidColorFillProperties.AddNewSrgbClr();
+                    ctSRgbColor.val = fillColor;
                 }
             }
         }

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -1,0 +1,116 @@
+﻿using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel.Charts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NPOI.XSSF.UserModel.Charts
+{
+    /// <summary>
+    /// Holds data for a XSSF Line Chart
+    /// </summary>
+    /// <typeparam name="Tx"></typeparam>
+    /// <typeparam name="Ty"></typeparam>
+    public class XSSFBarChartData<Tx, Ty> : IBarChartData<Tx, Ty>
+    {
+        /**
+         * List of all data series.
+         */
+        private List<IBarChartSeries<Tx, Ty>> series;
+
+        public XSSFBarChartData()
+        {
+            series = new List<IBarChartSeries<Tx, Ty>>();
+        }
+
+        public class Series : AbstractXSSFChartSeries, IBarChartSeries<Tx, Ty>
+        {
+            private int id;
+            private int order;
+            private IChartDataSource<Tx> categories;
+            private IChartDataSource<Ty> values;
+
+            internal Series(int id, int order,
+                            IChartDataSource<Tx> categories,
+                            IChartDataSource<Ty> values)
+            {
+                this.id = id;
+                this.order = order;
+                this.categories = categories;
+                this.values = values;
+            }
+
+            public IChartDataSource<Tx> GetCategoryAxisData()
+            {
+                return categories;
+            }
+
+            public IChartDataSource<Ty> GetValues()
+            {
+                return values;
+            }
+
+            internal void AddToChart(CT_BarChart ctBarChart)
+            {
+                CT_BarSer ctBarSer = ctBarChart.AddNewSer();
+                CT_BarGrouping ctGrouping = ctBarChart.AddNewGrouping();
+                ctGrouping.val = ST_BarGrouping.clustered;
+                ctBarSer.AddNewIdx().val = (uint)id;
+                ctBarSer.AddNewOrder().val = (uint)order;
+
+                CT_BarDir ctBarDir = ctBarChart.AddNewBarDir();
+                ctBarDir.val = ST_BarDir.col;
+
+                CT_AxDataSource catDS = ctBarSer.AddNewCat();
+                XSSFChartUtil.BuildAxDataSource(catDS, categories);
+                CT_NumDataSource valueDS = ctBarSer.AddNewVal();
+                XSSFChartUtil.BuildNumDataSource(valueDS, values);
+
+                if (IsTitleSet)
+                {
+                    ctBarSer.tx = GetCTSerTx();
+                }
+            }
+        }
+
+        public IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categoryAxisData, IChartDataSource<Ty> values)
+        {
+            if (!values.IsNumeric)
+            {
+                throw new ArgumentException("Value data source must be numeric.");
+            }
+            int numOfSeries = series.Count;
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
+            series.Add(newSeries);
+            return newSeries;
+        }
+
+        public List<IBarChartSeries<Tx, Ty>> GetSeries()
+        {
+            return series;
+        }
+
+        public void FillChart(SS.UserModel.IChart chart, params IChartAxis[] axis)
+        {
+            if (!(chart is XSSFChart))
+            {
+                throw new ArgumentException("Chart must be instance of XSSFChart");
+            }
+
+            XSSFChart xssfChart = (XSSFChart)chart;
+            CT_PlotArea plotArea = xssfChart.GetCTChart().plotArea;
+            CT_BarChart barChart = plotArea.AddNewBarChart();
+            barChart.AddNewVaryColors().val = 0;
+
+            foreach (Series s in series)
+            {
+                s.AddToChart(barChart);
+            }
+
+            foreach (IChartAxis ax in axis)
+            {
+                barChart.AddNewAxId().val = (uint)ax.Id;
+            }
+        }
+    }
+}

--- a/ooxml/XSSF/UserModel/Charts/XSSFCategoryAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFCategoryAxis.cs
@@ -78,6 +78,11 @@ namespace NPOI.XSSF.UserModel.Charts
             ctCatAx.crossAx.val = (uint)axis.Id;
         }
 
+        public void SetAuto(CT_Boolean au)
+        {
+            ctCatAx.auto = au;
+        }
+
         private void createAxis(long id, AxisPosition pos)
         {
             ctCatAx = chart.GetCTChart().plotArea.AddNewCatAx();

--- a/ooxml/XSSF/UserModel/Charts/XSSFCategoryAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFCategoryAxis.cs
@@ -68,6 +68,11 @@ namespace NPOI.XSSF.UserModel.Charts
             return ctCatAx.majorTickMark;
         }
 
+        public void SetMajorCTTickMark(CT_TickMark tm)
+        {
+            ctCatAx.majorTickMark = tm;
+        }
+
         protected override CT_TickMark GetMinorCTTickMark()
         {
             return ctCatAx.minorTickMark;

--- a/ooxml/XSSF/UserModel/Charts/XSSFChartAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFChartAxis.cs
@@ -212,11 +212,11 @@ namespace NPOI.XSSF.UserModel.Charts
         {
             get
             {
-                return GetDelete().val == 1;
+                return GetDelete().val == 0;
             }
             set
             {
-                GetDelete().val = value ? 1 : 0;
+                GetDelete().val = value ? 0 : 1;
             }
         }
 

--- a/ooxml/XSSF/UserModel/Charts/XSSFChartDataFactory.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFChartDataFactory.cs
@@ -45,6 +45,11 @@ namespace NPOI.XSSF.UserModel.Charts
         {
             return new XSSFLineChartData<Tx, Ty>();
         }
+
+        public IBarChartData<Tx, Ty> CreateBarChartData<Tx, Ty>()
+        {
+            return new XSSFBarChartData<Tx, Ty>();
+        }
         /**
          * @return factory instance
          */

--- a/ooxml/XSSF/UserModel/Charts/XSSFDateAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFDateAxis.cs
@@ -1,0 +1,124 @@
+﻿using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel.Charts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NPOI.XSSF.UserModel.Charts
+{
+    public class XSSFDateAxis : XSSFChartAxis
+    {
+        private CT_DateAx ctDateAx;
+
+        public XSSFDateAxis(XSSFChart chart, long id, AxisPosition pos)
+            : base(chart)
+        {
+
+            createAxis(id, pos);
+        }
+
+        public XSSFDateAxis(XSSFChart chart, CT_DateAx ctDateAx)
+            : base(chart)
+        {
+
+            this.ctDateAx = ctDateAx;
+        }
+
+        public override long Id
+        {
+            get
+            {
+                return ctDateAx.axId.val;
+            }
+        }
+
+        public CT_ShapeProperties Line
+        {
+            get
+            {
+                return ctDateAx.spPr;
+            }
+        }
+
+        protected override CT_AxPos GetCTAxPos()
+        {
+            return ctDateAx.axPos;
+        }
+
+        protected override CT_NumFmt GetCTNumFmt()
+        {
+            if (ctDateAx.IsSetNumFmt())
+            {
+                return ctDateAx.numFmt;
+            }
+            return ctDateAx.AddNewNumFmt();
+        }
+
+        protected override CT_Scaling GetCTScaling()
+        {
+            return ctDateAx.scaling;
+        }
+
+        protected override CT_Crosses GetCTCrosses()
+        {
+            return ctDateAx.crosses;
+        }
+
+        protected override CT_Boolean GetDelete()
+        {
+            return ctDateAx.delete;
+        }
+
+        protected override CT_TickMark GetMajorCTTickMark()
+        {
+            return ctDateAx.majorTickMark;
+        }
+
+        protected override CT_TickMark GetMinorCTTickMark()
+        {
+            return ctDateAx.minorTickMark;
+        }
+
+        protected CT_ChartLines GetMajorGridLines()
+        {
+            return ctDateAx.majorGridlines;
+        }
+
+        public override void CrossAxis(IChartAxis axis)
+        {
+            ctDateAx.crossAx.val = (uint)axis.Id;
+        }
+
+        public CT_TimeUnit GetBaseTimeUnit()
+        {
+            return ctDateAx.baseTimeUnit;
+        }
+
+        public void SetBaseTimeUnit(CT_TimeUnit unit)
+        {
+            ctDateAx.baseTimeUnit = unit;
+        }
+
+        private void createAxis(long id, AxisPosition pos)
+        {
+            ctDateAx = chart.GetCTChart().plotArea.AddNewDateAx();
+            ctDateAx.AddNewAxId().val = (uint)id;
+            ctDateAx.AddNewAxPos();
+            ctDateAx.AddNewScaling();
+            ctDateAx.AddNewCrosses();
+            ctDateAx.AddNewCrossAx();
+            ctDateAx.AddNewTickLblPos().val = ST_TickLblPos.nextTo;
+            ctDateAx.AddNewDelete();
+            ctDateAx.AddNewMajorTickMark();
+            ctDateAx.AddNewMinorTickMark();
+
+
+            this.Position = (pos);
+            this.Orientation = (AxisOrientation.MinToMax);
+            this.Crosses = (AxisCrosses.AutoZero);
+            this.IsVisible = true;
+            this.MajorTickMark = (AxisTickMark.Cross);
+            this.MinorTickMark = (AxisTickMark.None);
+        }
+    }
+}

--- a/ooxml/XSSF/UserModel/Charts/XSSFDateAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFDateAxis.cs
@@ -99,6 +99,11 @@ namespace NPOI.XSSF.UserModel.Charts
             ctDateAx.baseTimeUnit = unit;
         }
 
+        public void SetAuto(CT_Boolean au)
+        {
+            ctDateAx.auto = au;
+        }
+
         private void createAxis(long id, AxisPosition pos)
         {
             ctDateAx = chart.GetCTChart().plotArea.AddNewDateAx();

--- a/ooxml/XSSF/UserModel/Charts/XSSFDateAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFDateAxis.cs
@@ -74,6 +74,11 @@ namespace NPOI.XSSF.UserModel.Charts
             return ctDateAx.majorTickMark;
         }
 
+        public void SetMajorCTTickMark(CT_TickMark tm)
+        {
+            ctDateAx.majorTickMark = tm;
+        }
+
         protected override CT_TickMark GetMinorCTTickMark()
         {
             return ctDateAx.minorTickMark;

--- a/ooxml/XSSF/UserModel/Charts/XSSFLineChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFLineChartData.cs
@@ -40,6 +40,16 @@ namespace NPOI.XSSF.UserModel.Charts
                 this.values = values;
             }
 
+            public void SetId(int id)
+            {
+                this.id = id;
+            }
+
+            public void SetOrder(int order)
+            {
+                this.order = order;
+            }
+
             public IChartDataSource<Tx> GetCategoryAxisData() {
                 return categories;
             }
@@ -94,11 +104,15 @@ namespace NPOI.XSSF.UserModel.Charts
 
             XSSFChart xssfChart = (XSSFChart)chart;
             CT_PlotArea plotArea = xssfChart.GetCTChart().plotArea;
+            int allSeriesCount = plotArea.GetAllSeriesCount();
             CT_LineChart lineChart = plotArea.AddNewLineChart();
             lineChart.AddNewVaryColors().val = 0;
 
-            foreach (Series s in series)
+            for(int i = 0; i < series.Count; ++i)
             {
+                Series s = (Series)series[i];
+                s.SetId(allSeriesCount + i);
+                s.SetOrder(allSeriesCount + i);
                 s.AddToChart(lineChart);
             }
 

--- a/ooxml/XSSF/UserModel/Charts/XSSFLineChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFLineChartData.cs
@@ -1,7 +1,9 @@
-﻿using NPOI.OpenXmlFormats.Dml.Chart;
+﻿using NPOI.OpenXmlFormats.Dml;
+using NPOI.OpenXmlFormats.Dml.Chart;
 using NPOI.SS.UserModel.Charts;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 
 namespace NPOI.XSSF.UserModel.Charts
@@ -27,6 +29,7 @@ namespace NPOI.XSSF.UserModel.Charts
         {
             private int id;
             private int order;
+            private byte[] fillColor;
             private IChartDataSource<Tx> categories;
             private IChartDataSource<Ty> values;
 
@@ -48,6 +51,14 @@ namespace NPOI.XSSF.UserModel.Charts
             public void SetOrder(int order)
             {
                 this.order = order;
+            }
+
+            public void SetFillColor(Color color)
+            {
+                fillColor = new byte[3];
+                fillColor[0] = color.R;
+                fillColor[1] = color.G;
+                fillColor[2] = color.B;
             }
 
             public IChartDataSource<Tx> GetCategoryAxisData() {
@@ -75,6 +86,15 @@ namespace NPOI.XSSF.UserModel.Charts
 
                 if (IsTitleSet) {
                     ctLineSer.tx = GetCTSerTx();
+                }
+
+                if (fillColor != null)
+                {
+                    ctLineSer.spPr = new OpenXmlFormats.Dml.Chart.CT_ShapeProperties();
+                    CT_LineProperties ctLineProperties = ctLineSer.spPr.AddNewLn();
+                    CT_SolidColorFillProperties ctSolidColorFillProperties = ctLineProperties.AddNewSolidFill();
+                    CT_SRgbColor ctSRgbColor = ctSolidColorFillProperties.AddNewSrgbClr();
+                    ctSRgbColor.val = fillColor;
                 }
             }
         }

--- a/ooxml/XSSF/UserModel/Charts/XSSFScatterChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFScatterChartData.cs
@@ -70,6 +70,16 @@ namespace NPOI.XSSF.UserModel.Charts
                 this.ys = ys;
             }
 
+            public void SetId(int id)
+            {
+                this.id = id;
+            }
+
+            public void SetOrder(int order)
+            {
+                this.order = order;
+            }
+
             /**
              * Returns data source used for X axis values.
              * @return data source used for X axis values
@@ -136,11 +146,15 @@ namespace NPOI.XSSF.UserModel.Charts
 
             XSSFChart xssfChart = (XSSFChart)chart;
             CT_PlotArea plotArea = xssfChart.GetCTChart().plotArea;
+            int allSeriesCount = plotArea.GetAllSeriesCount();
             CT_ScatterChart scatterChart = plotArea.AddNewScatterChart();
             AddStyle(scatterChart);
 
-            foreach (Series s in series)
+            for (int i = 0; i < series.Count; ++i)
             {
+                Series s = (Series)series[i];
+                s.SetId(allSeriesCount + i);
+                s.SetOrder(allSeriesCount + i);
                 s.AddToChart(scatterChart);
             }
 

--- a/ooxml/XSSF/UserModel/Charts/XSSFValueAxis.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFValueAxis.cs
@@ -73,6 +73,11 @@ namespace NPOI.XSSF.UserModel.Charts
             return ctValAx.majorTickMark;
         }
 
+        public void SetMajorCTTickMark(CT_TickMark tm)
+        {
+            ctValAx.majorTickMark = tm;
+        }
+
         protected override CT_TickMark GetMinorCTTickMark()
         {
             return ctValAx.minorTickMark;

--- a/ooxml/XSSF/UserModel/XSSFChart.cs
+++ b/ooxml/XSSF/UserModel/XSSFChart.cs
@@ -211,6 +211,21 @@ namespace NPOI.XSSF.UserModel
             axis.Add(categoryAxis);
             return categoryAxis;
         }
+
+        public IChartAxis CreateDateAxis(AxisPosition pos)
+        {
+            long id = axis.Count + 1;
+            XSSFDateAxis dateAxis = new XSSFDateAxis(this, id, pos);
+            if (axis.Count == 1)
+            {
+                IChartAxis ax = axis[0];
+                ax.CrossAxis(dateAxis);
+                dateAxis.CrossAxis(ax);
+            }
+            axis.Add(dateAxis);
+            return dateAxis;
+        }
+
         public List<IChartAxis> GetAxis()
         {
             if (axis.Count == 0 && HasAxis())
@@ -312,7 +327,6 @@ namespace NPOI.XSSF.UserModel
                 axis.Add(new XSSFValueAxis(this, valAx));
             }
         }
-
     }
 }
 

--- a/ooxml/XSSF/UserModel/XSSFChart.cs
+++ b/ooxml/XSSF/UserModel/XSSFChart.cs
@@ -293,6 +293,11 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
+        public void SetCTDispBlanksAs(CT_DispBlanksAs disp)
+        {
+            chart.dispBlanksAs = disp;
+        }
+
         private bool HasAxis()
         {
             CT_PlotArea ctPlotArea = chart.plotArea;

--- a/ooxml/XWPF/Usermodel/XWPFDocument.cs
+++ b/ooxml/XWPF/Usermodel/XWPFDocument.cs
@@ -47,7 +47,7 @@ namespace NPOI.XWPF.UserModel
         /**
          * Keeps track on all id-values used in this document and included parts, like headers, footers, etc.
          */
-        private IdentifierManager drawingIdManager = new IdentifierManager(0L, 4294967295L);
+        private IdentifierManager drawingIdManager = new IdentifierManager(1L, 4294967295L);
         protected List<XWPFFooter> footers = new List<XWPFFooter>();
         protected List<XWPFHeader> headers = new List<XWPFHeader>();
         protected List<XWPFComment> comments = new List<XWPFComment>();


### PR DESCRIPTION
Add DateAxis for category axis. I want to set baseTimeUnit property for category axis in my project, but CT_CatAx in XSSFCategoryAxis doesn't has the property, so I make a XSSFDateAxis and a CT_DateAx inside it to make it work.