### PR TITLE
Delete conversion of day format 'dddd' to 'EEEE' in date format.

### DIFF
--- a/main/SS/UserModel/DataFormatter.cs
+++ b/main/SS/UserModel/DataFormatter.cs
@@ -76,9 +76,6 @@ namespace NPOI.SS.UserModel
         /** Pattern to find a number FormatBase: "0" or  "#" */
         private static string numPattern = "[0#]+";
 
-        /** Pattern to find days of week as text "ddd...." */
-        private static string daysAsText = "([d]{3,})";
-
         /** Pattern to find "AM/PM" marker */
         private static string amPmPattern = "((A|P)[M/P]*)";
 
@@ -415,14 +412,6 @@ namespace NPOI.SS.UserModel
                 formatStr = Regex.Replace(formatStr, amPmPattern, "@");
             }
             formatStr = formatStr.Replace("@", "tt");
-
-
-            MatchCollection match = Regex.Matches(formatStr, daysAsText);
-            if (match.Count > 0)
-            {
-                string replacement = match[0].Groups[0].Value.ToUpper().Replace("D", "E");
-                formatStr = Regex.Replace(formatStr, daysAsText, replacement);
-            }
 
 
             // Convert excel date FormatBase to SimpleDateFormat.


### PR DESCRIPTION
In Java POI, 'ddd' and 'dddd' of Excel day of the week are converted to Java 'EEE', 'EEEE', but in C# 'ddd', 'dddd' directly outputs the days of the week.
Currently 'EEEE' will be displayed as it is, so should not be replaced.

/main/SS/UserModel/DataFormatter.cs
```csharp
79:         /** Pattern to find days of week as text "ddd...." */
80:         private static string daysAsText = "([d]{3,})";
----
421:             MatchCollection match = Regex.Matches(formatStr, daysAsText);
422:             if (match.Count > 0)
423:             {
424:                 string replacement = match[0].Groups[0].Value.ToUpper().Replace("D", "E");
425:                 formatStr = Regex.Replace(formatStr, daysAsText, replacement);
426:             }
```
Current output.
```
EEEE, June 01, 2017
```

Delete replacement.
```
Thursday, June 01, 2017
```
