### PR TITLE
Key duplicate exception fix

### DIFF
--- a/ooxml/XSSF/Model/StylesTable.cs
+++ b/ooxml/XSSF/Model/StylesTable.cs
@@ -121,7 +121,7 @@ namespace NPOI.XSSF.Model
                     foreach (CT_NumFmt nfmt in ctfmts.numFmt)
                     {
                         int formatId = (int)nfmt.numFmtId;
-                        numberFormats.Add(formatId, nfmt.formatCode);
+                        numberFormats[formatId] = nfmt.formatCode;
                         usedNumberFormats[formatId] = true;
                     }
                 }
@@ -671,8 +671,3 @@ namespace NPOI.XSSF.Model
         }
     }
 }
-
-
-
-
-


### PR DESCRIPTION
Some xlsx files can't be loaded because have multiple records with one id. Office can open this files properly