### PR TITLE
Convert .NET Core class libraries to .NET Standard

### DIFF
--- a/OpenXmlFormats/NPOI.OpenXmlFormats.Core.csproj
+++ b/OpenXmlFormats/NPOI.OpenXmlFormats.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<AssemblyName>NPOI.OpenXmlFormats</AssemblyName>
 	<SignAssembly>true</SignAssembly>

--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<AssemblyName>NPOI</AssemblyName>
 	<RootNamespace>NPOI</RootNamespace>

--- a/ooxml/NPOI.OOXML.Core.csproj
+++ b/ooxml/NPOI.OOXML.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<AssemblyName>NPOI.OOXML</AssemblyName>
 	<RootNamespace>NPOI.OOXML</RootNamespace>

--- a/openxml4Net/NPOI.OpenXml4Net.Core.csproj
+++ b/openxml4Net/NPOI.OpenXml4Net.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<AssemblyName>NPOI.OpenXml4Net</AssemblyName>
 	<SignAssembly>true</SignAssembly>


### PR DESCRIPTION
This change allows .NET Framework applications to pull in the same class libraries -- the same binaries -- as a .NET Core application could, so that compatibility is increased.
This is an initial change; it's possible that a lower (i.e., more universal) version of .NET Standard could be used, but this is a starting point.