### PR TITLE
Fix POI bug 57423 ShiftRows() produces a corrupted xlsx file

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -2887,6 +2887,9 @@ namespace NPOI.XSSF.UserModel
                 map.Add(r.RowNum, r);
             }
             _rows = map;
+
+            // Sort CTRows by index asc.
+            worksheet.sheetData.row.Sort((row1, row2) => row1.r.CompareTo(row2.r));
         }
         private class ShiftCommentComparator : IComparer<XSSFComment>
         {


### PR DESCRIPTION
Bug reported here: https://bz.apache.org/bugzilla/show_bug.cgi?id=57423

Simple bugfix where CT_Rows are sorted at the end of ShiftRows().