### PR TITLE
Update XSSFWorkbook.cs - IsDate1904()

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -1643,6 +1643,10 @@ namespace NPOI.XSSF.UserModel
         public bool IsDate1904()
         {
             CT_WorkbookPr workbookPr = workbook.workbookPr;
+            
+            if (workbookPr == null)
+                return false;
+            
             return workbookPr.date1904Specified && workbookPr.date1904;
         }
 


### PR DESCRIPTION
Add a null check in IsDate1904(), returning the false default.

Needed for some computer generated xlsx files, which are missing this information and causing exceptions in this method.