### PR TITLE
Fixed an XSSFCellStyle that affects the same XSSFCBorder when updating XSSFCellStyle.Border*.

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFCellStyle.cs
+++ b/ooxml/XSSF/UserModel/XSSFCellStyle.cs
@@ -1061,7 +1061,7 @@ namespace NPOI.XSSF.UserModel
                 int idx = (int)_cellXf.borderId;
                 XSSFCellBorder cf = _stylesSource.GetBorderAt(idx);
 
-                ctBorder = (CT_Border)cf.GetCTBorder();
+                ctBorder = (CT_Border)cf.GetCTBorder().Copy();
             }
             else
             {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFCellStyle.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFCellStyle.cs
@@ -1052,5 +1052,44 @@ namespace NPOI.XSSF.UserModel
             wb.Close();
         }
 
+        [Test]
+        public void TestUpdateAnyBorderSideNotAffectsOthersSameXSSFCellBorder()
+        {
+            IWorkbook wb = new XSSFWorkbook();
+
+            ISheet sheet = wb.CreateSheet();
+            IRow row = sheet.CreateRow(0);
+
+            var cell1 = row.CreateCell(0);
+
+            var style1 = wb.CreateCellStyle();
+
+            style1.BorderBottom = BorderStyle.Double;
+
+            style1.BottomBorderColor = global::NPOI.SS.UserModel.IndexedColors.Black.Index;
+
+            cell1.CellStyle = style1;
+
+            Assert.AreEqual(BorderStyle.None, style1.BorderTop);
+
+            var cell2 = row.CreateCell(1);
+
+            var style2 = wb.CreateCellStyle();
+
+            style2.BorderBottom = BorderStyle.Double;
+
+            style2.BottomBorderColor = global::NPOI.SS.UserModel.IndexedColors.Black.Index;
+
+            style2.BorderTop = BorderStyle.Thin;
+
+            style2.TopBorderColor = global::NPOI.SS.UserModel.IndexedColors.Black.Index;
+
+            cell2.CellStyle = style2;
+
+            Assert.AreEqual(BorderStyle.None, style1.BorderTop);
+
+            wb.Close();
+        }
+
     }
 }


### PR DESCRIPTION
Fixed an XSSFCellStyle that affects the same XSSFCellBorder when updating XSSFCellStyle.Border*.

In fact, there is a long time pull request #92 , which has been fixed. But I don't know why there is no merger.

修正在更新 XSSFCellStyle.Border* 時，會影響同一 XSSFCellBorder 的 XSSFCellStyle。

其實有一個很久之前的 pull request #92 ，已經修正這問題。但不知為何沒合併。