### PR TITLE
#201 - XSSFFont CloneStyleFrom generates NPE if passed in src is null

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFFont.cs
+++ b/ooxml/XSSF/UserModel/XSSFFont.cs
@@ -658,22 +658,25 @@ namespace NPOI.XSSF.UserModel
 
         public void CloneStyleFrom(IFont src)
         {
-            if(src is XSSFFont)
+            if (src != null)
             {
-                _ctFont = ((XSSFFont)src)._ctFont;
-            }
-            else
-            {
-                FontName = src.FontName;
-                FontHeight = src.FontHeight;
-                IsBold = src.IsBold;
-                Boldweight = src.Boldweight;
-                IsItalic = src.IsItalic;
-                IsStrikeout = src.IsStrikeout;
-                Color = src.Color;
-                Underline = src.Underline;
-                Charset = src.Charset;
-                TypeOffset = src.TypeOffset;
+                if (src is XSSFFont)
+                {
+                    _ctFont = ((XSSFFont)src)._ctFont;
+                }
+                else
+                {
+                    FontName = src.FontName;
+                    FontHeight = src.FontHeight;
+                    IsBold = src.IsBold;
+                    Boldweight = src.Boldweight;
+                    IsItalic = src.IsItalic;
+                    IsStrikeout = src.IsStrikeout;
+                    Color = src.Color;
+                    Underline = src.Underline;
+                    Charset = src.Charset;
+                    TypeOffset = src.TypeOffset;
+                }
             }
         }
     }


### PR DESCRIPTION
Addressed by performing a null check before trying to clone style. 

After further testing, it also appears that this is a source for not just errors here, but was also causing corrupted xlsx files to be created.