### PR TITLE
Fix URI with Chinese Charset Issue

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFHyperlink.cs
+++ b/ooxml/XSSF/UserModel/XSSFHyperlink.cs
@@ -194,7 +194,7 @@ namespace NPOI.XSSF.UserModel
                 case HyperlinkType.Email:
                 case HyperlinkType.File:
                 case HyperlinkType.Url:
-                        if(!Uri.IsWellFormedUriString(address,UriKind.RelativeOrAbsolute))
+                        if(!Uri.TryCreate(address,UriKind.RelativeOrAbsolute,out Uri uri))
                             throw new ArgumentException("Address of hyperlink must be a valid URI:" + address);
                     break;
             }


### PR DESCRIPTION
Fix URI with Chinese Charset Issue

string path = @"Test/測試.pdf";
if (Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out Uri myUri))
{
	Console.Write("OK");
}
var newPath = Uri.EscapeUriString(path);
bool isWellFormedUriString = Uri.IsWellFormedUriString(newPath, UriKind.RelativeOrAbsolute);