### PR TITLE
fix literal, format, null-check

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Authors.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Authors.cs
@@ -13,8 +13,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     // not needed because it not used as a root [XmlRoot(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main", ElementName = "authors")]
     public class CT_Authors
     {
-
-        private List<string> authorField = null; // optional field [0..*]
+        [XmlElement(nameof(author))] // this is serialized into multiple author entries
+        public List<string> author { get; set; } = null;
 
         //public CT_Authors()
         //{
@@ -22,36 +22,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         //}
         public int SizeOfAuthorArray()
         {
-            return (null == authorField) ? 0 : authorField.Count;
+            return (int)author?.Count;
         }
         public string GetAuthorArray(int index)
         {
-            return (null == authorField) ? null : authorField[index];
+            return author?[index];
         }
         public void Insert(int index, string author)
         {
-            if (null == authorField) { authorField = new List<string>(); }
-            authorField.Insert(index, author);
+            if (null == this.author) { this.author = new List<string>(); }
+            this.author.Insert(index, author);
         }
         public void AddAuthor(string name)
         {
-            if (null == authorField) { authorField = new List<string>(); }
-            authorField.Add(name);
+            if (null == author) { author = new List<string>(); }
+            author.Add(name);
         }
         //[XmlArray("authors", Order = 0)] // - encapsulates the following items, but the outer element already provides the container.
         //[XmlArrayItem("author")]
-        [XmlElement("author")] // this is serialized into multiple author entries
-        public List<string> author
-        {
-            get
-            {
-                return this.authorField;
-            }
-            set
-            {
-                this.authorField = value;
-            }
-        }
         public static CT_Authors Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
@@ -70,15 +58,15 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}>", nodeName));
+            sw.Write($"<{nodeName}>");
             if (this.author != null)
             {
                 foreach (String x in this.author)
                 {
-                    sw.Write(string.Format("<author>{0}</author>", XmlHelper.EncodeXml(x)));
+                    sw.Write($"<author>{XmlHelper.EncodeXml(x)}</author>");
                 }
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write($"</{nodeName}>");
         }
 
     }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cell.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cell.cs
@@ -14,17 +14,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_Cell
     {
-
-        private CT_CellFormula fField = null;
-
-        private string vField = null;
-
-        private CT_Rst isField = null;
-
-        private CT_ExtensionList extLstField = null;
-
-        private string rField = null;
-
         private uint? sField = null;
 
         private ST_CellType? tField = null;
@@ -40,22 +29,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_Cell ctObj = new CT_Cell();
-            ctObj.r = XmlHelper.ReadString(node.Attributes["r"]);
-            ctObj.s = XmlHelper.ReadUInt(node.Attributes["s"]);
-            if (node.Attributes["t"] != null)
-                ctObj.t = (ST_CellType)Enum.Parse(typeof(ST_CellType), node.Attributes["t"].Value);
-            ctObj.cm = XmlHelper.ReadUInt(node.Attributes["cm"]);
-            ctObj.vm = XmlHelper.ReadUInt(node.Attributes["vm"]);
-            ctObj.ph = XmlHelper.ReadBool(node.Attributes["ph"]);
+            ctObj.r = XmlHelper.ReadString(node.Attributes[nameof(r)]);
+            ctObj.s = XmlHelper.ReadUInt(node.Attributes[nameof(s)]);
+            if (node.Attributes[nameof(t)] != null)
+                ctObj.t = (ST_CellType)Enum.Parse(typeof(ST_CellType), node.Attributes[nameof(t)].Value);
+            ctObj.cm = XmlHelper.ReadUInt(node.Attributes[nameof(cm)]);
+            ctObj.vm = XmlHelper.ReadUInt(node.Attributes[nameof(vm)]);
+            ctObj.ph = XmlHelper.ReadBool(node.Attributes[nameof(ph)]);
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "f")
+                if (childNode.LocalName == nameof(f))
                     ctObj.f = CT_CellFormula.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "v")
+                else if (childNode.LocalName == nameof(v))
                     ctObj.v = childNode.InnerText;
-                else if (childNode.LocalName == "is")
+                else if (childNode.LocalName == nameof(@is))
                     ctObj.@is = CT_Rst.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "extLst")
+                else if (childNode.LocalName == nameof(extLst))
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
             }
             return ctObj;
@@ -65,34 +54,32 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
+            sw.Write($"<{nodeName}");
 
-            XmlHelper.WriteAttribute(sw, "r", this.r);
-            XmlHelper.WriteAttribute(sw, "s", this.s);
+            XmlHelper.WriteAttribute(sw, nameof(r), this.r);
+            XmlHelper.WriteAttribute(sw, nameof(s), this.s);
             if (this.t != ST_CellType.n)
-                XmlHelper.WriteAttribute(sw, "t", this.t.ToString());
-            XmlHelper.WriteAttribute(sw, "cm", this.cm);
-            XmlHelper.WriteAttribute(sw, "vm", this.vm);
-            XmlHelper.WriteAttribute(sw, "ph", this.ph, false);
+                XmlHelper.WriteAttribute(sw, nameof(t), this.t.ToString());
+            XmlHelper.WriteAttribute(sw, nameof(cm), this.cm);
+            XmlHelper.WriteAttribute(sw, nameof(vm), this.vm);
+            XmlHelper.WriteAttribute(sw, nameof(ph), this.ph, false);
             if (this.f == null
                 && this.v == null
                 && this.@is == null
-                && this.extLstField == null)
+                && this.extLst == null)
             {
                 sw.Write("/>");
             }
             else
             {
+                // changed to null conditional
                 sw.Write(">");
-                if (this.f != null)
-                    this.f.Write(sw, "f");
+                this.f?.Write(sw, nameof(f));
                 if (this.v != null)
-                    sw.Write(string.Format("<v>{0}</v>", XmlHelper.EncodeXml(this.v)));
-                if (this.@is != null)
-                    this.@is.Write(sw, "is");
-                if (this.extLst != null)
-                    this.extLst.Write(sw, "extLst");
-                sw.Write(string.Format("</{0}>", nodeName));
+                    sw.Write($"<v>{XmlHelper.EncodeXml(this.v)}</v>");
+                this.@is?.Write(sw, nameof(@is));
+                this.extLst?.Write(sw, nameof(extLst));
+                sw.Write($"</{nodeName}>");
             }
         }
 
@@ -110,11 +97,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         //}
         public void Set(CT_Cell cell)
         {
-            fField = cell.fField;
-            vField = cell.vField;
-            isField = cell.isField;
-            extLstField = cell.extLstField;
-            rField = cell.rField;
+            f = cell.f;
+            v = cell.v;
+            @is = cell.@is;
+            extLst = cell.extLst;
+            r = cell.r;
             sField = cell.sField;
             tField = cell.tField;
             cmField = cell.cmField;
@@ -131,28 +118,28 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public bool IsSetF()
         {
-            return fField != null;
+            return f != null;
         }
         public bool IsSetV()
         {
-            return vField != null;
+            return v != null;
         }
         public bool IsSetIs()
         {
-            return isField != null;
+            return @is != null;
         }
         public bool IsSetR()
         {
-            return rField != null;
+            return r != null;
         }
         public void unsetF()
         {
-            this.fField = null;
+            this.f = null;
         }
 
         public void unsetV()
         {
-            this.vField = null;
+            this.v = null;
         }
 
         public void unsetS()
@@ -166,80 +153,34 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public void unsetIs()
         {
-            this.isField = null;
+            this.@is = null;
         }
         public void unsetR()
         {
-            this.rField = null;
+            this.r = null;
         }
         [XmlElement]
-        public CT_CellFormula f
-        {
-            get
-            {
-                return this.fField;
-            }
-            set
-            {
-                this.fField = value;
-            }
-        }
-        [XmlElement]
-        public string v
-        {
-            get
-            {
-                return this.vField;
-            }
-            set
-            {
-                this.vField = value;
-            }
-        }
+        public CT_CellFormula f { get; set; } = null;
 
-        [XmlElement("is")]
-        public CT_Rst @is
-        {
-            get
-            {
-                return this.isField;
-            }
-            set
-            {
-                this.isField = value;
-            }
-        }
         [XmlElement]
-        public CT_ExtensionList extLst
-        {
-            get
-            {
-                return this.extLstField;
-            }
-            set
-            {
-                this.extLstField = value;
-            }
-        }
+        public string v { get; set; } = null;
+
+        [XmlElement(nameof(@is))]
+        public CT_Rst @is { get; set; } = null;
+
+        [XmlElement]
+        public CT_ExtensionList extLst { get; set; } = null;
+
         [XmlAttribute]
-        public string r
-        {
-            get
-            {
-                return this.rField;
-            }
-            set
-            {
-                this.rField = value;
-            }
-        }
+        public string r { get; set; } = null;
+
         [XmlAttribute]
         [DefaultValue(typeof(uint), "0")]
         public uint s
         {
             get
             {
-                return null == sField ? 0 : (uint)this.sField;
+                return this.sField ?? 0;
             }
             set
             {
@@ -252,7 +193,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == tField ? ST_CellType.n : (ST_CellType)this.tField;
+                return this.tField ?? ST_CellType.n;
             }
             set
             {
@@ -265,7 +206,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == cmField ? 0 : (uint)this.cmField;
+                return this.cmField ?? 0;
             }
             set
             {
@@ -278,7 +219,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == vmField ? 0 : (uint)this.vmField;
+                return this.vmField ?? 0;
             }
             set
             {
@@ -291,7 +232,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == phField ? false : (bool)this.phField;
+                return this.phField ?? false;
             }
             set
             {

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
@@ -17,54 +17,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_Col
     {
-
-        private uint minField; // required
-
-        private uint maxField; // required
-
         private double widthField;  // optional, but width has no default value
-        private bool widthSpecifiedField;
-
-        private uint? styleField;// optional, as are the following attributes
-
-        private bool hiddenField;
-
-        private bool bestFitField;
-
-        private bool customWidthField;
-
-        private bool phoneticField;
-
-        private byte outlineLevelField;
-
         private bool collapsedField = true;
-        private bool collapsedSpecifiedField = true;
 
         [XmlAttribute]
-        public uint min
-        {
-            get
-            {
-                return this.minField;
-            }
-            set
-            {
-                this.minField = value;
-            }
-        }
+        public uint min { get; set; }
 
         [XmlAttribute]
-        public uint max
-        {
-            get
-            {
-                return this.maxField;
-            }
-            set
-            {
-                this.maxField = value;
-            }
-        }
+        public uint max { get; set; }
 
         [XmlAttribute]
         public double width
@@ -80,34 +40,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
         [XmlIgnore]
-        public bool widthSpecified
-        {
-            get
-            {
-                return this.widthSpecifiedField;
-            }
-            set
-            {
-                this.widthSpecifiedField = value;
-            }
-        }
+        public bool widthSpecified { get; set; }
 
 
         public bool IsSetBestFit()
         {
-            return this.bestFitField != false;
+            return this.bestFit != false;
         }
         public bool IsSetCustomWidth()
         {
-            return this.customWidthField != false;
+            return this.customWidth != false;
         }
         public bool IsSetHidden()
         {
-            return this.hiddenField != false;
+            return this.hidden != false;
         }
         public bool IsSetStyle()
         {
-            return this.styleField!=null;
+            return this.style!=null;
         }
         public bool IsSetWidth()
         {
@@ -115,19 +65,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public bool IsSetCollapsed()
         {
-            return this.collapsedSpecifiedField;
+            return this.collapsedSpecified;
         }
         public bool IsSetPhonetic()
         {
-            return this.phoneticField != false;
+            return this.phonetic != false;
         }
         public bool IsSetOutlineLevel()
         {
-            return this.outlineLevelField != 0;
+            return this.outlineLevel != 0;
         }
         public void UnsetHidden()
         {
-            this.hiddenField = false;
+            this.hidden = false;
         }
         public void UnsetCollapsed()
         {
@@ -138,87 +88,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
 
         [XmlAttribute]
-        public uint? style
-        {
-            get
-            {
-                return styleField;
-            }
-            set
-            {
-                this.styleField = value;
-            }
-        }
+        public uint? style { get; set; }
 
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool hidden
-        {
-            get
-            {
-                return hiddenField;
-            }
-            set
-            {
-                this.hiddenField = value;
-            }
-        }
+        public bool hidden { get; set; }
 
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool bestFit
-        {
-            get
-            {
-                return bestFitField;
-            }
-            set
-            {
-                this.bestFitField = value;
-            }
-        }
+        public bool bestFit { get; set; }
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool customWidth
-        {
-            get
-            {
-                return customWidthField;
-            }
-            set
-            {
-                this.customWidthField = value;
-            }
-        }
+        public bool customWidth { get; set; }
 
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool phonetic
-        {
-            get
-            {
-                return phoneticField;
-            }
-            set
-            {
-                this.phoneticField = value;
-            }
-        }
+        public bool phonetic { get; set; }
 
 
         [DefaultValue(typeof(byte), "0")]
         [XmlAttribute]
-        public byte outlineLevel
-        {
-            get
-            {
-                return outlineLevelField;
-            }
-            set
-            {
-                this.outlineLevelField = value;
-            }
-        }
+        public byte outlineLevel { get; set; }
 
         [DefaultValue(true)]
         [XmlAttribute]
@@ -231,15 +121,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             set
             {
                 this.collapsedField = value;
-                this.collapsedSpecifiedField = true;
+                this.collapsedSpecified = true;
             }
         }
         [XmlIgnore]
-        public bool collapsedSpecified
-        {
-            get { return this.collapsedSpecifiedField; }
-            set { this.collapsedSpecifiedField = value; }
-        }
+        public bool collapsedSpecified { get; set; } = true;
 
         public CT_Col()
         {
@@ -251,19 +137,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_Col ctObj = new CT_Col();
-            ctObj.min = XmlHelper.ReadUInt(node.Attributes["min"]);
-            ctObj.max = XmlHelper.ReadUInt(node.Attributes["max"]);
-            ctObj.width = XmlHelper.ReadDouble(node.Attributes["width"]);
-            if (node.Attributes["style"] != null)
-                ctObj.style = XmlHelper.ReadUInt(node.Attributes["style"]);
+            ctObj.min = XmlHelper.ReadUInt(node.Attributes[nameof(min)]);
+            ctObj.max = XmlHelper.ReadUInt(node.Attributes[nameof(max)]);
+            ctObj.width = XmlHelper.ReadDouble(node.Attributes[nameof(width)]);
+            if (node.Attributes[nameof(style)] != null)
+                ctObj.style = XmlHelper.ReadUInt(node.Attributes[nameof(style)]);
             else
                 ctObj.style = null;
-            ctObj.hidden = XmlHelper.ReadBool(node.Attributes["hidden"]);
-            ctObj.bestFit = XmlHelper.ReadBool(node.Attributes["bestFit"]);
-            ctObj.outlineLevel = XmlHelper.ReadByte(node.Attributes["outlineLevel"]);
-            ctObj.customWidth = XmlHelper.ReadBool(node.Attributes["customWidth"]);
-            ctObj.phonetic = XmlHelper.ReadBool(node.Attributes["phonetic"]);
-            ctObj.collapsed = XmlHelper.ReadBool(node.Attributes["collapsed"]);
+            ctObj.hidden = XmlHelper.ReadBool(node.Attributes[nameof(hidden)]);
+            ctObj.bestFit = XmlHelper.ReadBool(node.Attributes[nameof(bestFit)]);
+            ctObj.outlineLevel = XmlHelper.ReadByte(node.Attributes[nameof(outlineLevel)]);
+            ctObj.customWidth = XmlHelper.ReadBool(node.Attributes[nameof(customWidth)]);
+            ctObj.phonetic = XmlHelper.ReadBool(node.Attributes[nameof(phonetic)]);
+            ctObj.collapsed = XmlHelper.ReadBool(node.Attributes[nameof(collapsed)]);
             return ctObj;
         }
 
@@ -271,18 +157,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "min", this.min);
-            XmlHelper.WriteAttribute(sw, "max", this.max);
-            XmlHelper.WriteAttribute(sw, "width", this.width);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(min), this.min);
+            XmlHelper.WriteAttribute(sw, nameof(max), this.max);
+            XmlHelper.WriteAttribute(sw, nameof(width), this.width);
             if(this.style!=null)
-                XmlHelper.WriteAttribute(sw, "style", (uint)this.style,true);
-            XmlHelper.WriteAttribute(sw, "hidden", this.hidden,false);
-            XmlHelper.WriteAttribute(sw, "bestFit", this.bestFit,false);
-            XmlHelper.WriteAttribute(sw, "customWidth", this.customWidth,false);
-            XmlHelper.WriteAttribute(sw, "phonetic", this.phonetic,false);
-            XmlHelper.WriteAttribute(sw, "outlineLevel", this.outlineLevel);
-            XmlHelper.WriteAttribute(sw, "collapsed", this.collapsed,false);
+                XmlHelper.WriteAttribute(sw, nameof(style), (uint)this.style,true);
+            XmlHelper.WriteAttribute(sw, nameof(hidden), this.hidden,false);
+            XmlHelper.WriteAttribute(sw, nameof(bestFit), this.bestFit,false);
+            XmlHelper.WriteAttribute(sw, nameof(customWidth), this.customWidth,false);
+            XmlHelper.WriteAttribute(sw, nameof(phonetic), this.phonetic,false);
+            XmlHelper.WriteAttribute(sw, nameof(outlineLevel), this.outlineLevel);
+            XmlHelper.WriteAttribute(sw, nameof(collapsed), this.collapsed,false);
             sw.Write("/>");
         }
 
@@ -293,18 +179,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public CT_Col Copy()
         {
             CT_Col col = new CT_Col();
-            col.bestFitField = this.bestFitField;
+            col.bestFit = this.bestFit;
             col.collapsedField = this.collapsedField;
-            col.collapsedSpecifiedField = this.collapsedSpecifiedField;
-            col.customWidthField = this.customWidthField;
-            col.hiddenField = this.hiddenField;
-            col.maxField = this.maxField;
-            col.minField = this.minField;
-            col.outlineLevelField = this.outlineLevelField;
-            col.phoneticField = this.phoneticField;
-            col.styleField = this.styleField;
+            col.collapsedSpecified = this.collapsedSpecified;
+            col.customWidth = this.customWidth;
+            col.hidden = this.hidden;
+            col.max = this.max;
+            col.min = this.min;
+            col.outlineLevel = this.outlineLevel;
+            col.phonetic = this.phonetic;
+            col.style = this.style;
             col.widthField = this.widthField;
-            col.widthSpecifiedField = this.widthSpecifiedField;
+            col.widthSpecified = this.widthSpecified;
             
             return col;
         }
@@ -316,7 +202,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (!(obj is CT_Col))
                 return false;
             CT_Col col = obj as CT_Col;
-            return col.min == this.min && col.max == this.max;
+            return (col.min == this.min) && (col.max == this.max);
         }
 
         public override int GetHashCode()
@@ -326,7 +212,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public override string ToString()
         {
-            return string.Format("min:{0}, max:{1}, width:{2}", this.min, this.max, this.width);
+            return $"min:{this.min}, max:{this.max}, width:{this.width}";
         }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
@@ -14,31 +14,29 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     public class CT_Cols
     {
 
-        private List<CT_Col> colField = new List<CT_Col>(); // required
-
         //public CT_Cols()
         //{
         //    this.colField = new List<CT_Col>();
         //}
         public void SetColArray(List<CT_Col> array)
         {
-            colField = array;
+            col = array;
         }
         public CT_Col AddNewCol()
         {
             CT_Col newCol = new CT_Col();
-            this.colField.Add(newCol);
+            this.col.Add(newCol);
             return newCol;
         }
         public CT_Col InsertNewCol(int index)
         {
             CT_Col newCol = new CT_Col();
-            this.colField.Insert(index, newCol);
+            this.col.Insert(index, newCol);
             return newCol;
         }
         public void RemoveCol(int index)
         {
-            this.colField.RemoveAt(index);
+            this.col.RemoveAt(index);
         }
 
         public int sizeOfColArray()
@@ -47,36 +45,28 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public CT_Col GetColArray(int index)
         {
-            return colField[index];
+            return col[index];
         }
 
 
         public List<CT_Col> GetColList()
         {
-            return colField;
+            return col;
         }
         [XmlElement]
-        public List<CT_Col> col
-        {
-            get
-            {
-                return this.colField;
-            }
-            set
-            {
-                this.colField = value;
-            }
-        }
+        public List<CT_Col> col { get; set; } = new List<CT_Col>();
 
         public static CT_Cols Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
-            CT_Cols ctObj = new CT_Cols();
-            ctObj.col = new List<CT_Col>();
+            CT_Cols ctObj = new CT_Cols
+            {
+                col = new List<CT_Col>()
+            };
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "col")
+                if (childNode.LocalName == nameof(col))
                     ctObj.col.Add(CT_Col.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -86,23 +76,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
+            sw.Write($"<{nodeName}");
             sw.Write(">");
             if (this.col != null)
             {
                 foreach (CT_Col x in this.col)
                 {
-                    x.Write(sw, "col");
+                    x.Write(sw, nameof(col));
                 }
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write($"</{nodeName}>");
         }
 
 
 
-        public void SetColArray(CT_Col[] colArray)
+        public void SetColArray(IEnumerable<CT_Col> colArray)
         {
-            this.colField = new List<CT_Col>(colArray);
+            this.col = new List<CT_Col>(colArray);
         }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Comment.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Comment.cs
@@ -14,15 +14,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         ElementName = "comment")]
     public class CT_Comment
     {
-
-        private CT_Rst textField = new CT_Rst(); // required element 
-
-        private string refField = string.Empty; // required attribute
-
-        private uint authorIdField = 0; // required attribute
-
-        private string guidField = null; // optional attribute
-
         //public CT_Comment()
         //{
         //    this.textField = new CT_Rst();
@@ -32,78 +23,38 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_Comment ctObj = new CT_Comment();
-            ctObj.@ref = XmlHelper.ReadString(node.Attributes["ref"]);
-            if (node.Attributes["authorId"] != null)
-                ctObj.authorId = XmlHelper.ReadUInt(node.Attributes["authorId"]);
-            ctObj.guid = XmlHelper.ReadString(node.Attributes["guid"]);
+            ctObj.@ref = XmlHelper.ReadString(node.Attributes[nameof(@ref)]);
+            if (node.Attributes[nameof(authorId)] != null)
+                ctObj.authorId = XmlHelper.ReadUInt(node.Attributes[nameof(authorId)]);
+            ctObj.guid = XmlHelper.ReadString(node.Attributes[nameof(guid)]);
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "text")
+                if (childNode.LocalName == nameof(text))
                     ctObj.text = CT_Rst.Parse(childNode, namespaceManager);
             }
             return ctObj;
         }
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "ref", this.@ref);
-            XmlHelper.WriteAttribute(sw, "authorId", this.authorId, true);
-            XmlHelper.WriteAttribute(sw, "guid", this.guid);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(@ref), this.@ref);
+            XmlHelper.WriteAttribute(sw, nameof(authorId), this.authorId, true);
+            XmlHelper.WriteAttribute(sw, nameof(guid), this.guid);
             sw.Write(">");
             if (this.text != null)
-                this.text.Write(sw, "text");
-            sw.Write(string.Format("</{0}>", nodeName));
+                this.text.Write(sw, nameof(text));
+            sw.Write($"</{nodeName}>");
         }
-        [XmlElement("text")]
-        public CT_Rst text
-        {
-            get
-            {
-                return this.textField;
-            }
-            set
-            {
-                this.textField = value;
-            }
-        }
+        [XmlElement(nameof(text))]
+        public CT_Rst text { get; set; } = new CT_Rst();
 
-        [XmlAttribute("ref")]
-        public string @ref
-        {
-            get
-            {
-                return this.refField;
-            }
-            set
-            {
-                this.refField = value;
-            }
-        }
+        [XmlAttribute(nameof(@ref))]
+        public string @ref { get; set; } = string.Empty;
 
-        [XmlAttribute("authorId")]
-        public uint authorId
-        {
-            get
-            {
-                return this.authorIdField;
-            }
-            set
-            {
-                this.authorIdField = value;
-            }
-        }
+        [XmlAttribute(nameof(authorId))]
+        public uint authorId { get; set; } = 0;
 
-        [XmlAttribute("guid")] // 0..1 TODO: Type is ST_Guid
-        public string guid
-        {
-            get
-            {
-                return this.guidField;
-            }
-            set
-            {
-                this.guidField = value;
-            }
-        }
+        [XmlAttribute(nameof(guid))] // 0..1 TODO: Type is ST_Guid
+        public string guid { get; set; } = null;
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_CommentList.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_CommentList.cs
@@ -7,6 +7,7 @@
 namespace NPOI.OpenXmlFormats.Spreadsheet
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using System.IO;
     using System.Xml;
@@ -25,7 +26,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.comment = new List<CT_Comment>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "comment")
+                if (childNode.LocalName == nameof(comment))
                     ctObj.comment.Add(CT_Comment.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -35,15 +36,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}>", nodeName));
-            if (this.comment != null)
-            {
-                foreach (CT_Comment x in this.comment)
-                {
-                    x.Write(sw, "comment");
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write($"<{nodeName}>");
+            this.comment?.ForEach(x => x.Write(sw, nameof(this.comment)));
+            sw.Write($"</{nodeName}>");
         }
 
         private List<CT_Comment> commentField = null; // optional field [0..*]
@@ -69,18 +64,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             if (null == commentField) { commentField = new List<CT_Comment>(); }
             CT_Comment com = new CT_Comment();
-            commentField.Insert(index,com);
-            return com;            
+            commentField.Insert(index, com);
+            return com;
         }
         public CT_Comment AddNewComment()
         {
             if (null == commentField) { commentField = new List<CT_Comment>(); }
-            CT_Comment com= new CT_Comment();
+            CT_Comment com = new CT_Comment();
             commentField.Add(com);
             return com;
         }
 
-        [XmlElement("comment")]
+        [XmlElement(nameof(comment))]
         public List<CT_Comment> comment
         {
             get

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Comments.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Comments.cs
@@ -14,11 +14,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         ElementName = "comments")]
     public class CT_Comments
     {
-        private CT_Authors authorsField = new CT_Authors(); // required field
-
-        private CT_CommentList commentListField = new CT_CommentList(); // required field
-
-        private CT_ExtensionList extLstField = null; // optional field
         public static CT_Comments Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
@@ -26,11 +21,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             CT_Comments ctObj = new CT_Comments();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "authors")
+                if (childNode.LocalName == nameof(authors))
                     ctObj.authors = CT_Authors.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "commentList")
+                else if (childNode.LocalName == nameof(commentList))
                     ctObj.commentList = CT_CommentList.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "extLst")
+                else if (childNode.LocalName == nameof(extLst))
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
             }
             return ctObj;
@@ -39,60 +34,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>");
             sw.Write("<comments xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
-            if (this.authors != null)
-                this.authors.Write(sw, "authors");
-            if (this.commentList != null)
-                this.commentList.Write(sw, "commentList");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
+            this.authors?.Write(sw, nameof(authors));
+            this.commentList?.Write(sw, nameof(commentList));
+            this.extLst?.Write(sw, nameof(extLst));
             sw.Write("</comments>");
         }
         public CT_Authors AddNewAuthors()
         {
-            this.authorsField = new CT_Authors();
-            return this.authorsField;
+            this.authors = new CT_Authors();
+            return this.authors;
         }
         public void AddNewCommentList()
         {
-            this.commentListField = new CT_CommentList();
+            this.commentList = new CT_CommentList();
         }
 
-        [XmlElement("authors", Order = 0)]
-        public CT_Authors authors
-        {
-            get
-            {
-                return this.authorsField;
-            }
-            set
-            {
-                this.authorsField = value;
-            }
-        }
-        [XmlElement("commentList", Order = 1)]
-        public CT_CommentList commentList
-        {
-            get
-            {
-                return this.commentListField;
-            }
-            set
-            {
-                this.commentListField = value;
-            }
-        }
+        [XmlElement(nameof(authors), Order = 0)]
+        public CT_Authors authors { get; set; } = new CT_Authors();
+        [XmlElement(nameof(commentList), Order = 1)]
+        public CT_CommentList commentList { get; set; } = new CT_CommentList();
 
-        [XmlElement("extLst", Order = 2)]
-        public CT_ExtensionList extLst
-        {
-            get
-            {
-                return this.extLstField;
-            }
-            set
-            {
-                this.extLstField = value;
-            }
-        }
+        [XmlElement(nameof(extLst), Order = 2)]
+        public CT_ExtensionList extLst { get; set; } = null;
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Hyperlink.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Hyperlink.cs
@@ -12,92 +12,31 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_Hyperlink
     {
-
-        private string refField = null;
-
-        private string idField = null; // this and the other ones are optional
-
-        private string locationField = null;
-
-        private string tooltipField = null;
-
-        private string displayField = null;
-
-        [XmlAttribute("ref")]
-        public string @ref
-        {
-            get
-            {
-                return this.refField;
-            }
-            set
-            {
-                this.refField = value;
-            }
-        }
+        [XmlAttribute(nameof(@ref))]
+        public string @ref { get; set; } = null;
 
         [XmlAttribute(Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships")]
-        public string id
-        {
-            get
-            {
-                return this.idField;
-            }
-            set
-            {
-                this.idField = value;
-            }
-        }
+        public string id { get; set; } = null;
 
         [XmlAttribute]
-        public string location
-        {
-            get
-            {
-                return this.locationField;
-            }
-            set
-            {
-                this.locationField = value;
-            }
-        }
+        public string location { get; set; } = null;
 
         [XmlAttribute]
-        public string tooltip
-        {
-            get
-            {
-                return this.tooltipField;
-            }
-            set
-            {
-                this.tooltipField = value;
-            }
-        }
+        public string tooltip { get; set; } = null;
 
         [XmlAttribute]
-        public string display
-        {
-            get
-            {
-                return this.displayField;
-            }
-            set
-            {
-                this.displayField = value;
-            }
-        }
+        public string display { get; set; } = null;
 
         public static CT_Hyperlink Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
             CT_Hyperlink ctObj = new CT_Hyperlink();
-            ctObj.@ref = XmlHelper.ReadString(node.Attributes["ref"]);
-            ctObj.id = XmlHelper.ReadString(node.Attributes["id", PackageNamespaces.SCHEMA_RELATIONSHIPS]);
-            ctObj.location = XmlHelper.ReadString(node.Attributes["location"]);
-            ctObj.tooltip = XmlHelper.ReadString(node.Attributes["tooltip"]);
-            ctObj.display = XmlHelper.ReadString(node.Attributes["display"]);
+            ctObj.@ref = XmlHelper.ReadString(node.Attributes[nameof(@ref)]);
+            ctObj.id = XmlHelper.ReadString(node.Attributes[nameof(id), PackageNamespaces.SCHEMA_RELATIONSHIPS]);
+            ctObj.location = XmlHelper.ReadString(node.Attributes[nameof(location)]);
+            ctObj.tooltip = XmlHelper.ReadString(node.Attributes[nameof(tooltip)]);
+            ctObj.display = XmlHelper.ReadString(node.Attributes[nameof(display)]);
             return ctObj;
         }
 
@@ -105,14 +44,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "ref", this.@ref);
-            XmlHelper.WriteAttribute(sw, "r:id", this.id);
-            XmlHelper.WriteAttribute(sw, "location", this.location);
-            XmlHelper.WriteAttribute(sw, "tooltip", this.tooltip);
-            XmlHelper.WriteAttribute(sw, "display", this.display);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(@ref), this.@ref);
+            XmlHelper.WriteAttribute(sw, $"r:{nameof(id)}", this.id);
+            XmlHelper.WriteAttribute(sw, nameof(location), this.location);
+            XmlHelper.WriteAttribute(sw, nameof(tooltip), this.tooltip);
+            XmlHelper.WriteAttribute(sw, nameof(display), this.display);
             sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write($"</{nodeName}>");
         }
 
 

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_MergeCell.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_MergeCell.cs
@@ -18,7 +18,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_MergeCell ctObj = new CT_MergeCell();
-            ctObj.@ref = XmlHelper.ReadString(node.Attributes["ref"]);
+            ctObj.@ref = XmlHelper.ReadString(node.Attributes[nameof(@ref)]);
             return ctObj;
         }
 
@@ -26,24 +26,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
     internal void Write(StreamWriter sw, string nodeName)
     {
-        sw.Write(string.Format("<{0}", nodeName));
-        XmlHelper.WriteAttribute(sw, "ref", this.@ref);
+        sw.Write($"<{nodeName}");
+        XmlHelper.WriteAttribute(sw, nameof(@ref), this.@ref);
         sw.Write("/>");
     }
-
-
-        private string refField;
         [XmlAttribute]
-        public string @ref
-        {
-            get
-            {
-                return this.refField;
-            }
-            set
-            {
-                this.refField = value;
-            }
-        }
+        public string @ref { get; set; }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_MergeCells.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_MergeCells.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
 using System.Xml;
@@ -14,23 +14,16 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_MergeCells
     {
-
-        private List<CT_MergeCell> mergeCellField;
-
-        private uint countField;
-
-        private bool countFieldSpecified;
-
         public static CT_MergeCells Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
             CT_MergeCells ctObj = new CT_MergeCells();
-            ctObj.count = XmlHelper.ReadUInt(node.Attributes["count"]);
+            ctObj.count = XmlHelper.ReadUInt(node.Attributes[nameof(count)]);
             ctObj.mergeCell = new List<CT_MergeCell>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "mergeCell")
+                if (childNode.LocalName == nameof(mergeCell))
                     ctObj.mergeCell.Add(CT_MergeCell.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -40,33 +33,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "count", this.count);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(count), this.count);
             sw.Write(">");
-            if (this.mergeCell != null)
-            {
-                foreach (CT_MergeCell x in this.mergeCell)
-                {
-                    if (x != null) {
-                        x.Write(sw, "mergeCell");
-                    }
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
+            mergeCell?.ForEach(x => x?.Write(sw, nameof(mergeCell)));
+            sw.Write($"</{nodeName}>");
         }
 
 
         public CT_MergeCells()
         {
-            this.mergeCellField = new List<CT_MergeCell>();
+            this.mergeCell = new List<CT_MergeCell>();
         }
         public CT_MergeCell GetMergeCellArray(int index)
         {
-            return this.mergeCellField[index];
+            return this.mergeCell[index];
         }
-        public void SetMergeCellArray(CT_MergeCell[] array)
+        public void SetMergeCellArray(IEnumerable<CT_MergeCell> array)
         {
-            mergeCell = new List<CT_MergeCell>(array);
+            mergeCell = array.ToList();
         }
         public int sizeOfMergeCellArray()
         {
@@ -79,41 +64,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             return mergecell;
         }
         [XmlElement]
-        public List<CT_MergeCell> mergeCell
-        {
-            get
-            {
-                return this.mergeCellField;
-            }
-            set
-            {
-                this.mergeCellField = value;
-            }
-        }
+        public List<CT_MergeCell> mergeCell { get; set; }
         [XmlAttribute]
-        public uint count
-        {
-            get
-            {
-                return this.countField;
-            }
-            set
-            {
-                this.countField = value;
-            }
-        }
+        public uint count { get; set; }
 
         [XmlIgnore]
-        public bool countSpecified
-        {
-            get
-            {
-                return this.countFieldSpecified;
-            }
-            set
-            {
-                this.countFieldSpecified = value;
-            }
-        }
+        public bool countSpecified { get; set; }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-
+using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
 using System.Xml;
@@ -14,60 +14,32 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_Row
     {
-
-        private List<CT_Cell> cField = null; // optional element
-
-        private CT_ExtensionList extLstField = null; // optional element
-
-        // the following are all optional attributes
-        private uint rField;
-
-        private string spansField = null; // a region is contained in this field, e.g. "1:3"
-
-        private uint sField;
-
-        private bool customFormatField;
-
-        private double htField=-1;
-
-        private bool hiddenField;
-
-        private bool customHeightField;
-
-        private byte outlineLevelField;
-
-        private bool collapsedField;
-
-        private bool thickTopField;
-
-        private bool thickBotField;
-
-        private bool phField;
-
         public static CT_Row Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
-            CT_Row ctObj = new CT_Row();
-            ctObj.r = XmlHelper.ReadUInt(node.Attributes["r"]);
-            ctObj.spans = XmlHelper.ReadString(node.Attributes["spans"]);
-            ctObj.s = XmlHelper.ReadUInt(node.Attributes["s"]);
-            ctObj.customFormat = XmlHelper.ReadBool(node.Attributes["customFormat"]);
-            if (node.Attributes["ht"]!=null)
-                ctObj.ht = XmlHelper.ReadDouble(node.Attributes["ht"]);
-            ctObj.hidden = XmlHelper.ReadBool(node.Attributes["hidden"]);
-            ctObj.outlineLevel = XmlHelper.ReadByte(node.Attributes["outlineLevel"]);
-            ctObj.customHeight = XmlHelper.ReadBool(node.Attributes["customHeight"]);
-            ctObj.collapsed = XmlHelper.ReadBool(node.Attributes["collapsed"]);
-            ctObj.thickTop = XmlHelper.ReadBool(node.Attributes["thickTop"]);
-            ctObj.thickBot = XmlHelper.ReadBool(node.Attributes["thickBot"]);
-            ctObj.ph = XmlHelper.ReadBool(node.Attributes["ph"]);
+            CT_Row ctObj = new CT_Row
+            {
+                r = XmlHelper.ReadUInt(node.Attributes[nameof(r)]),
+                spans = XmlHelper.ReadString(node.Attributes[nameof(spans)]),
+                s = XmlHelper.ReadUInt(node.Attributes[nameof(s)]),
+                customFormat = XmlHelper.ReadBool(node.Attributes[nameof(customFormat)])
+            };
+            if (node.Attributes[nameof(ht)] != null)
+                ctObj.ht = XmlHelper.ReadDouble(node.Attributes[nameof(ht)]);
+            ctObj.hidden = XmlHelper.ReadBool(node.Attributes[nameof(hidden)]);
+            ctObj.outlineLevel = XmlHelper.ReadByte(node.Attributes[nameof(outlineLevel)]);
+            ctObj.customHeight = XmlHelper.ReadBool(node.Attributes[nameof(customHeight)]);
+            ctObj.collapsed = XmlHelper.ReadBool(node.Attributes[nameof(collapsed)]);
+            ctObj.thickTop = XmlHelper.ReadBool(node.Attributes[nameof(thickTop)]);
+            ctObj.thickBot = XmlHelper.ReadBool(node.Attributes[nameof(thickBot)]);
+            ctObj.ph = XmlHelper.ReadBool(node.Attributes[nameof(ph)]);
             ctObj.c = new List<CT_Cell>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "extLst")
+                if (childNode.LocalName == nameof(extLst))
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "c")
+                else if (childNode.LocalName == nameof(c))
                     ctObj.c.Add(CT_Cell.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -77,305 +49,158 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "r", this.r);
-            XmlHelper.WriteAttribute(sw, "spans", this.spans);
-            XmlHelper.WriteAttribute(sw, "s", this.s);
-            XmlHelper.WriteAttribute(sw, "customFormat", this.customFormat,false);
-            if(this.ht>=0)
-                XmlHelper.WriteAttribute(sw, "ht", this.ht);
-            XmlHelper.WriteAttribute(sw, "hidden", this.hidden,false);
-            XmlHelper.WriteAttribute(sw, "customHeight", this.customHeight,false);
-            XmlHelper.WriteAttribute(sw, "outlineLevel", this.outlineLevel);
-            XmlHelper.WriteAttribute(sw, "collapsed", this.collapsed, false);
-            XmlHelper.WriteAttribute(sw, "thickTop", this.thickTop,false);
-            XmlHelper.WriteAttribute(sw, "thickBot", this.thickBot,false);
-            XmlHelper.WriteAttribute(sw, "ph", this.ph, false);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(r), this.r);
+            XmlHelper.WriteAttribute(sw, nameof(spans), this.spans);
+            XmlHelper.WriteAttribute(sw, nameof(s), this.s);
+            XmlHelper.WriteAttribute(sw, nameof(customFormat), this.customFormat, false);
+            if (this.ht >= 0)
+                XmlHelper.WriteAttribute(sw, nameof(ht), this.ht);
+            XmlHelper.WriteAttribute(sw, nameof(hidden), this.hidden, false);
+            XmlHelper.WriteAttribute(sw, nameof(customHeight), this.customHeight, false);
+            XmlHelper.WriteAttribute(sw, nameof(outlineLevel), this.outlineLevel);
+            XmlHelper.WriteAttribute(sw, nameof(collapsed), this.collapsed, false);
+            XmlHelper.WriteAttribute(sw, nameof(thickTop), this.thickTop, false);
+            XmlHelper.WriteAttribute(sw, nameof(thickBot), this.thickBot, false);
+            XmlHelper.WriteAttribute(sw, nameof(ph), this.ph, false);
             sw.Write(">");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            if (this.c != null)
-            {
-                foreach (CT_Cell x in this.c)
-                {
-                    x.Write(sw, "c");
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
+            this.extLst?.Write(sw, nameof(extLst));
+            this.c?.ForEach(x => x.Write(sw, nameof(c)));
+            sw.Write($"</{nodeName}>");
         }
 
 
 
         public void Set(CT_Row row)
         {
-            cField = row.cField;
-            extLstField = row.extLstField;
-            rField = row.rField;
-            spansField = row.spansField;
-            sField = row.sField;
-            customFormatField = row.customFormatField;
-            htField = row.htField;
-            hiddenField = row.hiddenField;
-            customHeightField = row.customHeightField;
-            outlineLevelField = row.outlineLevelField;
-            collapsedField = row.collapsedField;
-            thickTopField = row.thickTopField;
-            thickBotField = row.thickBotField;
-            phField = row.phField;
+            c = row.c;
+            extLst = row.extLst;
+            r = row.r;
+            spans = row.spans;
+            s = row.s;
+            customFormat = row.customFormat;
+            ht = row.ht;
+            hidden = row.hidden;
+            customHeight = row.customHeight;
+            outlineLevel = row.outlineLevel;
+            collapsed = row.collapsed;
+            thickTop = row.thickTop;
+            thickBot = row.thickBot;
+            ph = row.ph;
         }
         public CT_Cell AddNewC()
         {
-            if (null == cField) { cField = new List<CT_Cell>(); }
+            if (null == c) { c = new List<CT_Cell>(); }
             CT_Cell cell = new CT_Cell();
-            this.cField.Add(cell);
+            this.c.Add(cell);
             return cell;
         }
         public void UnsetCollapsed()
         {
-            this.collapsedField = false;
+            this.collapsed = false;
         }
         public void UnsetS()
         {
-            this.sField = 0;
+            this.s = 0;
         }
         public void UnsetCustomFormat()
         {
-            this.customFormatField = false;
+            this.customFormat = false;
         }
         public bool IsSetHidden()
         {
-            return this.hiddenField != false;
+            return this.hidden != false;
         }
         public bool IsSetCollapsed()
         {
-            return this.collapsedField != false;
+            return this.collapsed != false;
         }
         public bool IsSetHt()
         {
-            return this.htField >=0;
+            return this.ht >= 0;
         }
         public void unSetHt()
         {
-            this.htField = -1;
+            this.ht = -1;
         }
         public bool IsSetCustomHeight()
         {
-            return this.customHeightField != false;
+            return this.customHeight != false;
         }
         public void unSetCustomHeight()
         {
-            this.customHeightField = false;
+            this.customHeight = false;
         }
         public bool IsSetS()
         {
-            return this.sField != 0;
+            return this.s != 0;
         }
         public void unsetHidden()
         {
-            this.hiddenField = false;
+            this.hidden = false;
         }
 
         public int SizeOfCArray()
         {
-            return (null == cField) ? 0 : cField.Count;
+            return c?.Count ?? 0;
         }
         public CT_Cell GetCArray(int index)
         {
-            return (null == cField) ? null : cField[index];
+            return c?[index];
         }
-        public void SetCArray(CT_Cell[] array)
+        public void SetCArray(IEnumerable<CT_Cell> cells)
         {
-            cField = new List<CT_Cell>(array);
+            c = cells.ToList();
         }
-        [XmlElement("c")]
-        public List<CT_Cell> c
-        {
-            get
-            {
-                return this.cField;
-            }
-            set
-            {
-                this.cField = value;
-            }
-        }
-        [XmlElement("extLst")]
-        public CT_ExtensionList extLst
-        {
-            get
-            {
-                return this.extLstField;
-            }
-            set
-            {
-                this.extLstField = value;
-            }
-        }
+        [XmlElement(nameof(c))]
+        public List<CT_Cell> c { get; set; } = null;
+        [XmlElement(nameof(extLst))]
+        public CT_ExtensionList extLst { get; set; } = null;
 
-        [XmlAttribute("r")]
-        public uint r
-        {
-            get
-            {
-                return this.rField;
-            }
-            set
-            {
-                this.rField = value;
-            }
-        }
+        [XmlAttribute(nameof(r))]
+        public uint r { get; set; }
 
         [XmlAttribute]
-        public string spans
-        {
-            get
-            {
-                return this.spansField;
-            }
-            set
-            {
-                this.spansField = value;
-            }
-        }
+        public string spans { get; set; } = null;
 
         //[DefaultValue(typeof(uint), "0")]
         [XmlAttribute]
-        public uint s
-        {
-            get
-            {
-                return this.sField;
-            }
-            set
-            {
-                this.sField = value;
-            }
-        }
+        public uint s { get; set; }
 
         //[DefaultValue(false)]
         [XmlAttribute]
-        public bool customFormat
-        {
-            get
-            {
-                return this.customFormatField;
-            }
-            set
-            {
-                this.customFormatField = value;
-            }
-        }
+        public bool customFormat { get; set; }
         [XmlAttribute]
-        public double ht
-        {
-            get
-            {
-                return this.htField;
-            }
-            set
-            {
-                this.htField = value;
-            }
-        }
+        public double ht { get; set; } = -1;
 
 
         //[DefaultValue(false)]
         [XmlAttribute]
-        public bool hidden
-        {
-            get
-            {
-                return this.hiddenField;
-            }
-            set
-            {
-                this.hiddenField = value;
-            }
-        }
+        public bool hidden { get; set; }
 
         //[DefaultValue(false)]
         [XmlAttribute]
-        public bool customHeight
-        {
-            get
-            {
-                return this.customHeightField;
-            }
-            set
-            {
-                this.customHeightField = value;
-            }
-        }
+        public bool customHeight { get; set; }
 
         [DefaultValue(typeof(byte), "0")]
         [XmlAttribute]
-        public byte outlineLevel
-        {
-            get
-            {
-                return this.outlineLevelField;
-            }
-            set
-            {
-                this.outlineLevelField = value;
-            }
-        }
+        public byte outlineLevel { get; set; }
 
         //[DefaultValue(false)]
         [XmlAttribute]
-        public bool collapsed
-        {
-            get
-            {
-                return this.collapsedField;
-            }
-            set
-            {
-                this.collapsedField = value;
-            }
-        }
+        public bool collapsed { get; set; }
 
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool thickTop
-        {
-            get
-            {
-                return this.thickTopField;
-            }
-            set
-            {
-                this.thickTopField = value;
-            }
-        }
+        public bool thickTop { get; set; }
 
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool thickBot
-        {
-            get
-            {
-                return this.thickBotField;
-            }
-            set
-            {
-                this.thickBotField = value;
-            }
-        }
+        public bool thickBot { get; set; }
 
         [DefaultValue(false)]
         [XmlAttribute]
-        public bool ph
-        {
-            get
-            {
-                return this.phField;
-            }
-            set
-            {
-                this.phField = value;
-            }
-        }
+        public bool ph { get; set; }
     }
 
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Sheet.cs
@@ -16,108 +16,61 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlRoot("sheet", Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main", IsNullable = true)]
     public class CT_Sheet
     {
-
-        private string nameField;
-
-        private uint sheetIdField;
-
-        private ST_SheetState stateField;
-
-        private string idField;
-
         public static CT_Sheet Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
-            CT_Sheet ctObj = new CT_Sheet();
-            ctObj.name = XmlHelper.ReadString(node.Attributes["name"]);
-            ctObj.sheetId = XmlHelper.ReadUInt(node.Attributes["sheetId"]);
-            if (node.Attributes["state"] != null)
-                ctObj.state = (ST_SheetState)Enum.Parse(typeof(ST_SheetState), node.Attributes["state"].Value);
-            ctObj.id = XmlHelper.ReadString(node.Attributes["id", PackageNamespaces.SCHEMA_RELATIONSHIPS]);
+            CT_Sheet ctObj = new CT_Sheet
+            {
+                name = XmlHelper.ReadString(node.Attributes[nameof(name)]),
+                sheetId = XmlHelper.ReadUInt(node.Attributes[nameof(sheetId)])
+            };
+            if (node.Attributes[nameof(state)] != null)
+                ctObj.state = (ST_SheetState)Enum.Parse(typeof(ST_SheetState), node.Attributes[nameof(state)].Value);
+            ctObj.id = XmlHelper.ReadString(node.Attributes[nameof(id), PackageNamespaces.SCHEMA_RELATIONSHIPS]);
             return ctObj;
         }
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "sheetId", this.sheetId);
-            if(state!= ST_SheetState.visible)
-                XmlHelper.WriteAttribute(sw, "state", this.state.ToString());
-            XmlHelper.WriteAttribute(sw, "r:id", this.id);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(name), this.name);
+            XmlHelper.WriteAttribute(sw, nameof(sheetId), this.sheetId);
+            if (state != ST_SheetState.visible)
+                XmlHelper.WriteAttribute(sw, nameof(state), this.state.ToString());
+            XmlHelper.WriteAttribute(sw, $"r:{nameof(id)}", this.id);
             sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write($"</{nodeName}>");
         }
 
         public CT_Sheet()
         {
-            this.stateField = ST_SheetState.visible;
+            this.state = ST_SheetState.visible;
         }
         public void Set(CT_Sheet sheet)
         {
-            this.nameField = sheet.nameField;
-            this.sheetIdField = sheet.sheetIdField;
-            this.stateField = sheet.stateField;
-            this.idField = sheet.idField;
+            this.name = sheet.name;
+            this.sheetId = sheet.sheetId;
+            this.state = sheet.state;
+            this.id = sheet.id;
         }
         public CT_Sheet Copy()
         {
             CT_Sheet obj = new CT_Sheet();
-            obj.idField = this.idField;
-            obj.sheetIdField = this.sheetIdField;
-            obj.nameField = this.nameField;
-            obj.stateField = this.stateField;
+            obj.id = this.id;
+            obj.sheetId = this.sheetId;
+            obj.name = this.name;
+            obj.state = this.state;
             return obj;
         }
-        [XmlAttribute("name")]
-        public string name
-        {
-            get
-            {
-                return this.nameField;
-            }
-            set
-            {
-                this.nameField = value;
-            }
-        }
-        [XmlAttribute("sheetId")]
-        public uint sheetId
-        {
-            get
-            {
-                return this.sheetIdField;
-            }
-            set
-            {
-                this.sheetIdField = value;
-            }
-        }
-        [XmlAttribute("state")]
+        [XmlAttribute(nameof(name))]
+        public string name { get; set; }
+        [XmlAttribute(nameof(sheetId))]
+        public uint sheetId { get; set; }
+        [XmlAttribute(nameof(state))]
         [DefaultValue(ST_SheetState.visible)]
-        public ST_SheetState state
-        {
-            get
-            {
-                return this.stateField;
-            }
-            set
-            {
-                this.stateField = value;
-            }
-        }
+        public ST_SheetState state { get; set; }
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified, Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships")]
-        public string id
-        {
-            get
-            {
-                return this.idField;
-            }
-            set
-            {
-                this.idField = value;
-            }
-        }
+        public string id { get; set; }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetData.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetData.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
 using System.Xml;
@@ -21,7 +21,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.row = new List<CT_Row>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "row")
+                if (childNode.LocalName == nameof(row))
                     ctObj.row.Add(CT_Row.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -31,21 +31,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
+            sw.Write($"<{nodeName}");
             sw.Write(">");
-            if (this.row != null)
-            {
-                foreach (CT_Row x in this.row)
-                {
-                    x.Write(sw, "row");
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
+            this.row?.ForEach(x => x.Write(sw, nameof(row)));
+            sw.Write($"</{nodeName}>");
         }
-
-
-
-        private List<CT_Row> rowField = null; // [0..*] 
 
         //public CT_SheetData()
         //{
@@ -53,32 +43,32 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         //}
         public CT_Row AddNewRow()
         {
-            if (null == rowField) { rowField = new List<CT_Row>(); }
+            if (null == row) { row = new List<CT_Row>(); }
             CT_Row newrow = new CT_Row();
-            rowField.Add(newrow);
+            row.Add(newrow);
             return newrow;
         }
         public CT_Row InsertNewRow(int index)
         {
-            if (null == rowField) { rowField = new List<CT_Row>(); }
+            if (null == row) { row = new List<CT_Row>(); }
             CT_Row newrow = new CT_Row();
-            rowField.Insert(index, newrow);
+            row.Insert(index, newrow);
             return newrow;
         }
         public void RemoveRows(IList<CT_Row> toRemove)
         {
-            if (rowField == null) return;
+            if (row == null) return;
             foreach (CT_Row r in toRemove)
             {
-                rowField.Remove(r);
+                row.Remove(r);
             }
         }
         public void RemoveRow(int rowNum)
         {
-            if (null != rowField)
+            if (null != row)
             {
                 CT_Row rowToRemove=null;
-                foreach (CT_Row ctrow in rowField)
+                foreach (CT_Row ctrow in row)
                 {
                     if (ctrow.r == rowNum)
                     {
@@ -86,34 +76,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                         break;
                     }
                 }
-                rowField.Remove(rowToRemove);
+                row.Remove(rowToRemove);
             }
         }
         public int SizeOfRowArray()
         {
-            return (null == rowField) ? 0 : rowField.Count;
+            return row?.Count ?? 0;
         }
 
         public CT_Row GetRowArray(int index)
         {
-            return (null == rowField) ? null : rowField[index];
+            return row?[index];
         }
-        [XmlElement("row")]
-        public List<CT_Row> row
-        {
-            get
-            {
-                return this.rowField;
-            }
-            set
-            {
-                this.rowField = value;
-            }
-        }
+        [XmlElement(nameof(row))]
+        public List<CT_Row> row { get; set; } = null;
         [XmlIgnore]
         public bool rowSpecified
         {
-            get { return null != rowField; }
+            get { return null != row; }
         }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetPr.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetPr.cs
@@ -14,52 +14,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_SheetPr
     {
-
-        private CT_Color tabColorField;
-
-        private CT_OutlinePr outlinePrField;
-
-        private CT_PageSetUpPr pageSetUpPrField;
-
-        private bool syncHorizontalField;
-
-        private bool syncVerticalField;
-
-        private string syncRefField;
-
-        private bool transitionEvaluationField;
-
-        private bool transitionEntryField;
-
-        private bool publishedField;
-
-        private string codeNameField;
-
-        private bool filterModeField;
-
-        private bool enableFormatConditionsCalculationField;
-
         public static CT_SheetPr Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
             CT_SheetPr ctObj = new CT_SheetPr();
-            ctObj.syncHorizontal = XmlHelper.ReadBool(node.Attributes["syncHorizontal"]);
-            ctObj.syncVertical = XmlHelper.ReadBool(node.Attributes["syncVertical"]);
-            ctObj.syncRef = XmlHelper.ReadString(node.Attributes["syncRef"]);
-            ctObj.transitionEvaluation = XmlHelper.ReadBool(node.Attributes["transitionEvaluation"]);
-            ctObj.transitionEntry = XmlHelper.ReadBool(node.Attributes["transitionEntry"]);
-            ctObj.published = XmlHelper.ReadBool(node.Attributes["published"]);
-            ctObj.codeName = XmlHelper.ReadString(node.Attributes["codeName"]);
-            ctObj.filterMode = XmlHelper.ReadBool(node.Attributes["filterMode"]);
-            ctObj.enableFormatConditionsCalculation = XmlHelper.ReadBool(node.Attributes["enableFormatConditionsCalculation"]);
+            ctObj.syncHorizontal = XmlHelper.ReadBool(node.Attributes[nameof(syncHorizontal)]);
+            ctObj.syncVertical = XmlHelper.ReadBool(node.Attributes[nameof(syncVertical)]);
+            ctObj.syncRef = XmlHelper.ReadString(node.Attributes[nameof(syncRef)]);
+            ctObj.transitionEvaluation = XmlHelper.ReadBool(node.Attributes[nameof(transitionEvaluation)]);
+            ctObj.transitionEntry = XmlHelper.ReadBool(node.Attributes[nameof(transitionEntry)]);
+            ctObj.published = XmlHelper.ReadBool(node.Attributes[nameof(published)]);
+            ctObj.codeName = XmlHelper.ReadString(node.Attributes[nameof(codeName)]);
+            ctObj.filterMode = XmlHelper.ReadBool(node.Attributes[nameof(filterMode)]);
+            ctObj.enableFormatConditionsCalculation = XmlHelper.ReadBool(node.Attributes[nameof(enableFormatConditionsCalculation)]);
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "tabColor")
+                if (childNode.LocalName == nameof(tabColor))
                     ctObj.tabColor = CT_Color.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "outlinePr")
+                else if (childNode.LocalName == nameof(outlinePr))
                     ctObj.outlinePr = CT_OutlinePr.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "pageSetUpPr")
+                else if (childNode.LocalName == nameof(pageSetUpPr))
                     ctObj.pageSetUpPr = CT_PageSetUpPr.Parse(childNode, namespaceManager);
             }
             return ctObj;
@@ -69,24 +44,21 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "syncHorizontal", this.syncHorizontal, false);
-            XmlHelper.WriteAttribute(sw, "syncVertical", this.syncVertical, false);
-            XmlHelper.WriteAttribute(sw, "syncRef", this.syncRef);
-            XmlHelper.WriteAttribute(sw, "transitionEvaluation", this.transitionEvaluation, false);
-            XmlHelper.WriteAttribute(sw, "transitionEntry", this.transitionEntry, false);
-            XmlHelper.WriteAttribute(sw, "published", this.published, false);
-            XmlHelper.WriteAttribute(sw, "codeName", this.codeName);
-            XmlHelper.WriteAttribute(sw, "filterMode", this.filterMode,false);
-            XmlHelper.WriteAttribute(sw, "enableFormatConditionsCalculation", this.enableFormatConditionsCalculation, false);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(syncHorizontal), this.syncHorizontal, false);
+            XmlHelper.WriteAttribute(sw, nameof(syncVertical), this.syncVertical, false);
+            XmlHelper.WriteAttribute(sw, nameof(syncRef), this.syncRef);
+            XmlHelper.WriteAttribute(sw, nameof(transitionEvaluation), this.transitionEvaluation, false);
+            XmlHelper.WriteAttribute(sw, nameof(transitionEntry), this.transitionEntry, false);
+            XmlHelper.WriteAttribute(sw, nameof(published), this.published, false);
+            XmlHelper.WriteAttribute(sw, nameof(codeName), this.codeName);
+            XmlHelper.WriteAttribute(sw, nameof(filterMode), this.filterMode,false);
+            XmlHelper.WriteAttribute(sw, nameof(enableFormatConditionsCalculation), this.enableFormatConditionsCalculation, false);
             sw.Write(">");
-            if (this.tabColor != null)
-                this.tabColor.Write(sw, "tabColor");
-            if (this.outlinePr != null)
-                this.outlinePr.Write(sw, "outlinePr");
-            if (this.pageSetUpPr != null)
-                this.pageSetUpPr.Write(sw, "pageSetUpPr");
-            sw.Write(string.Format("</{0}>", nodeName));
+            this.tabColor?.Write(sw, nameof(tabColor));
+            this.outlinePr?.Write(sw, nameof(outlinePr));
+            this.pageSetUpPr?.Write(sw, nameof(pageSetUpPr));
+            sw.Write($"</{nodeName}>");
         }
 
 
@@ -95,211 +67,94 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             //this.pageSetUpPrField = new CT_PageSetUpPr();
             //this.outlinePrField = new CT_OutlinePr();
             //this.tabColorField = new CT_Color();
-            this.syncHorizontalField = false;
-            this.syncVerticalField = false;
-            this.transitionEvaluationField = false;
-            this.transitionEntryField = false;
-            this.publishedField = true;
-            this.filterModeField = false;
-            this.enableFormatConditionsCalculationField = true;
+            this.syncHorizontal = false;
+            this.syncVertical = false;
+            this.transitionEvaluation = false;
+            this.transitionEntry = false;
+            this.published = true;
+            this.filterMode = false;
+            this.enableFormatConditionsCalculation = true;
         }
         public CT_SheetPr Clone()
         {
-            CT_SheetPr newPr = new CT_SheetPr();
-            newPr.codeNameField = codeNameField;
-            newPr.enableFormatConditionsCalculationField = enableFormatConditionsCalculationField;
-            newPr.filterModeField = filterModeField;
-            newPr.publishedField = publishedField;
-            newPr.syncHorizontalField = syncHorizontalField;
-            newPr.syncRefField = syncRefField;
-            newPr.syncVerticalField = syncVerticalField;
-            newPr.transitionEntryField = transitionEntryField;
-            newPr.transitionEvaluationField = transitionEvaluationField;
-            if (outlinePrField != null)
+            CT_SheetPr newPr = new CT_SheetPr
             {
-                newPr.outlinePrField = outlinePrField.Clone();
+                codeName = codeName,
+                enableFormatConditionsCalculation = enableFormatConditionsCalculation,
+                filterMode = filterMode,
+                published = published,
+                syncHorizontal = syncHorizontal,
+                syncRef = syncRef,
+                syncVertical = syncVertical,
+                transitionEntry = transitionEntry,
+                transitionEvaluation = transitionEvaluation
+            };
+
+            if (outlinePr != null)
+            {
+                newPr.outlinePr = outlinePr.Clone();
             }
-            if (pageSetUpPrField != null)
+            if (pageSetUpPr != null)
             {
-                newPr.pageSetUpPrField = pageSetUpPrField.Clone();
+                newPr.pageSetUpPr = pageSetUpPr.Clone();
             }
-            if (tabColorField != null)
+            if (tabColor != null)
             {
-                newPr.tabColorField = tabColorField.Copy();
+                newPr.tabColor = tabColor.Copy();
             }
             return newPr;
         }
 
         public bool IsSetOutlinePr()
         {
-            return this.outlinePrField != null;
+            return this.outlinePr != null;
         }
         public bool IsSetPageSetUpPr()
         {
-            return this.pageSetUpPrField != null;
+            return this.pageSetUpPr != null;
         }
         public CT_PageSetUpPr AddNewPageSetUpPr()
         {
-            this.pageSetUpPrField = new CT_PageSetUpPr();
-            return this.pageSetUpPrField;
+            this.pageSetUpPr = new CT_PageSetUpPr();
+            return this.pageSetUpPr;
         }
         public CT_OutlinePr AddNewOutlinePr()
         {
-            this.outlinePrField = new CT_OutlinePr();
-            return this.outlinePrField;
+            this.outlinePr = new CT_OutlinePr();
+            return this.outlinePr;
         }
 
 
-        public CT_Color tabColor
-        {
-            get
-            {
-                return this.tabColorField;
-            }
-            set
-            {
-                this.tabColorField = value;
-            }
-        }
+        public CT_Color tabColor { get; set; }
 
-        public CT_OutlinePr outlinePr
-        {
-            get
-            {
-                return this.outlinePrField;
-            }
-            set
-            {
-                this.outlinePrField = value;
-            }
-        }
+        public CT_OutlinePr outlinePr { get; set; }
 
-        public CT_PageSetUpPr pageSetUpPr
-        {
-            get
-            {
-                return this.pageSetUpPrField;
-            }
-            set
-            {
-                this.pageSetUpPrField = value;
-            }
-        }
+        public CT_PageSetUpPr pageSetUpPr { get; set; }
 
         [DefaultValue(false)]
-        public bool syncHorizontal
-        {
-            get
-            {
-                return this.syncHorizontalField;
-            }
-            set
-            {
-                this.syncHorizontalField = value;
-            }
-        }
+        public bool syncHorizontal { get; set; }
 
         [DefaultValue(false)]
-        public bool syncVertical
-        {
-            get
-            {
-                return this.syncVerticalField;
-            }
-            set
-            {
-                this.syncVerticalField = value;
-            }
-        }
+        public bool syncVertical { get; set; }
 
-        public string syncRef
-        {
-            get
-            {
-                return this.syncRefField;
-            }
-            set
-            {
-                this.syncRefField = value;
-            }
-        }
+        public string syncRef { get; set; }
 
         [DefaultValue(false)]
-        public bool transitionEvaluation
-        {
-            get
-            {
-                return this.transitionEvaluationField;
-            }
-            set
-            {
-                this.transitionEvaluationField = value;
-            }
-        }
+        public bool transitionEvaluation { get; set; }
 
         [DefaultValue(false)]
-        public bool transitionEntry
-        {
-            get
-            {
-                return this.transitionEntryField;
-            }
-            set
-            {
-                this.transitionEntryField = value;
-            }
-        }
+        public bool transitionEntry { get; set; }
 
         [DefaultValue(true)]
-        public bool published
-        {
-            get
-            {
-                return this.publishedField;
-            }
-            set
-            {
-                this.publishedField = value;
-            }
-        }
+        public bool published { get; set; }
 
-        public string codeName
-        {
-            get
-            {
-                return this.codeNameField;
-            }
-            set
-            {
-                this.codeNameField = value;
-            }
-        }
+        public string codeName { get; set; }
 
         [DefaultValue(false)]
-        public bool filterMode
-        {
-            get
-            {
-                return this.filterModeField;
-            }
-            set
-            {
-                this.filterModeField = value;
-            }
-        }
+        public bool filterMode { get; set; }
 
         [DefaultValue(true)]
-        public bool enableFormatConditionsCalculation
-        {
-            get
-            {
-                return this.enableFormatConditionsCalculationField;
-            }
-            set
-            {
-                this.enableFormatConditionsCalculationField = value;
-            }
-        }
+        public bool enableFormatConditionsCalculation { get; set; }
 
         public bool IsSetTabColor()
         {

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
@@ -1,5 +1,6 @@
 ﻿using NPOI.OpenXml4Net.Util;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -16,75 +17,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlRoot("table", Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main", IsNullable = true)]
     public class CT_Table
     {
-
-        private CT_AutoFilter autoFilterField;
-
-        private CT_SortState sortStateField;
-
-        private CT_TableColumns tableColumnsField;
-
-        private CT_TableStyleInfo tableStyleInfoField;
-
-        private CT_ExtensionList extLstField;
-
-        private uint idField;
-
-        private string nameField;
-
-        private string displayNameField;
-
-        private string commentField;
-
-        private string refField;
-
-        private ST_TableType tableTypeField;
-
-        private uint headerRowCountField;
-
-        private bool insertRowField;
-
-        private bool insertRowShiftField;
-
-        private uint totalsRowCountField;
-
-        private bool totalsRowShownField;
-
-        private bool publishedField;
-
-        private uint headerRowDxfIdField;
-
-        private bool headerRowDxfIdFieldSpecified;
-
-        private uint dataDxfIdField;
-
-        private bool dataDxfIdFieldSpecified;
-
-        private uint totalsRowDxfIdField;
-
-        private bool totalsRowDxfIdFieldSpecified;
-
-        private uint headerRowBorderDxfIdField;
-
-        private bool headerRowBorderDxfIdFieldSpecified;
-
-        private uint tableBorderDxfIdField;
-
-        private bool tableBorderDxfIdFieldSpecified;
-
-        private uint totalsRowBorderDxfIdField;
-
-        private bool totalsRowBorderDxfIdFieldSpecified;
-
-        private string headerRowCellStyleField;
-
-        private string dataCellStyleField;
-
-        private string totalsRowCellStyleField;
-
-        private uint connectionIdField;
-
-        private bool connectionIdFieldSpecified;
-
         public CT_Table()
         {
             //this.extLstField = new CT_ExtensionList();
@@ -92,67 +24,67 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             //this.tableColumnsField = new CT_TableColumns();
             //this.sortStateField = new CT_SortState();
             //this.autoFilterField = new CT_AutoFilter();
-            this.tableTypeField = ST_TableType.worksheet;
-            this.headerRowCountField = ((uint)(1));
-            this.insertRowField = false;
-            this.insertRowShiftField = false;
-            this.totalsRowCountField = ((uint)(0));
-            this.totalsRowShownField = true;
-            this.publishedField = false;
+            this.tableType = ST_TableType.worksheet;
+            this.headerRowCount = ((uint)(1));
+            this.insertRow = false;
+            this.insertRowShift = false;
+            this.totalsRowCount = ((uint)(0));
+            this.totalsRowShown = true;
+            this.published = false;
         }
         public static CT_Table Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
             CT_Table ctObj = new CT_Table();
-            if (node.Attributes["id"] != null)
-                ctObj.id = XmlHelper.ReadUInt(node.Attributes["id"]);
-            ctObj.name = XmlHelper.ReadString(node.Attributes["name"]);
-            ctObj.displayName = XmlHelper.ReadString(node.Attributes["displayName"]);
-            ctObj.comment = XmlHelper.ReadString(node.Attributes["comment"]);
-            ctObj.@ref = XmlHelper.ReadString(node.Attributes["ref"]);
-            if (node.Attributes["tableType"] != null)
-                ctObj.tableType = (ST_TableType)Enum.Parse(typeof(ST_TableType), node.Attributes["tableType"].Value);
-            if (node.Attributes["headerRowCount"] != null)
-                ctObj.headerRowCount = XmlHelper.ReadUInt(node.Attributes["headerRowCount"]);
-            if (node.Attributes["insertRow"] != null)
-                ctObj.insertRow = XmlHelper.ReadBool(node.Attributes["insertRow"]);
-            if (node.Attributes["insertRowShift"] != null)
-                ctObj.insertRowShift = XmlHelper.ReadBool(node.Attributes["insertRowShift"]);
-            if (node.Attributes["totalsRowCount"] != null)
-                ctObj.totalsRowCount = XmlHelper.ReadUInt(node.Attributes["totalsRowCount"]);
-            if (node.Attributes["totalsRowShown"] != null)
-                ctObj.totalsRowShown = XmlHelper.ReadBool(node.Attributes["totalsRowShown"]);
-            if (node.Attributes["published"] != null)
-                ctObj.published = XmlHelper.ReadBool(node.Attributes["published"]);
-            if (node.Attributes["headerRowDxfId"] != null)
-                ctObj.headerRowDxfId = XmlHelper.ReadUInt(node.Attributes["headerRowDxfId"]);
-            if (node.Attributes["dataDxfId"] != null)
-                ctObj.dataDxfId = XmlHelper.ReadUInt(node.Attributes["dataDxfId"]);
-            if (node.Attributes["totalsRowDxfId"] != null)
-                ctObj.totalsRowDxfId = XmlHelper.ReadUInt(node.Attributes["totalsRowDxfId"]);
-            if (node.Attributes["headerRowBorderDxfId"] != null)
-                ctObj.headerRowBorderDxfId = XmlHelper.ReadUInt(node.Attributes["headerRowBorderDxfId"]);
-            if (node.Attributes["tableBorderDxfId"] != null)
-                ctObj.tableBorderDxfId = XmlHelper.ReadUInt(node.Attributes["tableBorderDxfId"]);
-            if (node.Attributes["totalsRowBorderDxfId"] != null)
-                ctObj.totalsRowBorderDxfId = XmlHelper.ReadUInt(node.Attributes["totalsRowBorderDxfId"]);
-            ctObj.headerRowCellStyle = XmlHelper.ReadString(node.Attributes["headerRowCellStyle"]);
-            ctObj.dataCellStyle = XmlHelper.ReadString(node.Attributes["dataCellStyle"]);
-            ctObj.totalsRowCellStyle = XmlHelper.ReadString(node.Attributes["totalsRowCellStyle"]);
-            if (node.Attributes["connectionId"] != null)
-                ctObj.connectionId = XmlHelper.ReadUInt(node.Attributes["connectionId"]);
+            if (node.Attributes[nameof(id)] != null)
+                ctObj.id = XmlHelper.ReadUInt(node.Attributes[nameof(id)]);
+            ctObj.name = XmlHelper.ReadString(node.Attributes[nameof(name)]);
+            ctObj.displayName = XmlHelper.ReadString(node.Attributes[nameof(displayName)]);
+            ctObj.comment = XmlHelper.ReadString(node.Attributes[nameof(comment)]);
+            ctObj.@ref = XmlHelper.ReadString(node.Attributes[nameof(@ref)]);
+            if (node.Attributes[nameof(tableType)] != null)
+                ctObj.tableType = (ST_TableType)Enum.Parse(typeof(ST_TableType), node.Attributes[nameof(tableType)].Value);
+            if (node.Attributes[nameof(headerRowCount)] != null)
+                ctObj.headerRowCount = XmlHelper.ReadUInt(node.Attributes[nameof(headerRowCount)]);
+            if (node.Attributes[nameof(insertRow)] != null)
+                ctObj.insertRow = XmlHelper.ReadBool(node.Attributes[nameof(insertRow)]);
+            if (node.Attributes[nameof(insertRowShift)] != null)
+                ctObj.insertRowShift = XmlHelper.ReadBool(node.Attributes[nameof(insertRowShift)]);
+            if (node.Attributes[nameof(totalsRowCount)] != null)
+                ctObj.totalsRowCount = XmlHelper.ReadUInt(node.Attributes[nameof(totalsRowCount)]);
+            if (node.Attributes[nameof(totalsRowShown)] != null)
+                ctObj.totalsRowShown = XmlHelper.ReadBool(node.Attributes[nameof(totalsRowShown)]);
+            if (node.Attributes[nameof(published)] != null)
+                ctObj.published = XmlHelper.ReadBool(node.Attributes[nameof(published)]);
+            if (node.Attributes[nameof(headerRowDxfId)] != null)
+                ctObj.headerRowDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(headerRowDxfId)]);
+            if (node.Attributes[nameof(dataDxfId)] != null)
+                ctObj.dataDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(dataDxfId)]);
+            if (node.Attributes[nameof(totalsRowDxfId)] != null)
+                ctObj.totalsRowDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(totalsRowDxfId)]);
+            if (node.Attributes[nameof(headerRowBorderDxfId)] != null)
+                ctObj.headerRowBorderDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(headerRowBorderDxfId)]);
+            if (node.Attributes[nameof(tableBorderDxfId)] != null)
+                ctObj.tableBorderDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(tableBorderDxfId)]);
+            if (node.Attributes[nameof(totalsRowBorderDxfId)] != null)
+                ctObj.totalsRowBorderDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(totalsRowBorderDxfId)]);
+            ctObj.headerRowCellStyle = XmlHelper.ReadString(node.Attributes[nameof(headerRowCellStyle)]);
+            ctObj.dataCellStyle = XmlHelper.ReadString(node.Attributes[nameof(dataCellStyle)]);
+            ctObj.totalsRowCellStyle = XmlHelper.ReadString(node.Attributes[nameof(totalsRowCellStyle)]);
+            if (node.Attributes[nameof(connectionId)] != null)
+                ctObj.connectionId = XmlHelper.ReadUInt(node.Attributes[nameof(connectionId)]);
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "autoFilter")
+                if (childNode.LocalName == nameof(autoFilter))
                     ctObj.autoFilter = CT_AutoFilter.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sortState")
+                else if (childNode.LocalName == nameof(sortState))
                     ctObj.sortState = CT_SortState.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "tableColumns")
+                else if (childNode.LocalName == nameof(tableColumns))
                     ctObj.tableColumns = CT_TableColumns.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "tableStyleInfo")
+                else if (childNode.LocalName == nameof(tableStyleInfo))
                     ctObj.tableStyleInfo = CT_TableStyleInfo.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "extLst")
+                else if (childNode.LocalName == nameof(extLst))
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
             }
             return ctObj;
@@ -165,475 +97,123 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
             sw.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
             sw.Write("<table xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"");
-            XmlHelper.WriteAttribute(sw, "id", this.id);
-            XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "displayName", this.displayName);
-            XmlHelper.WriteAttribute(sw, "comment", this.comment);
-            XmlHelper.WriteAttribute(sw, "ref", this.@ref);
-            XmlHelper.WriteAttribute(sw, "tableType", this.tableType.ToString());
-            XmlHelper.WriteAttribute(sw, "headerRowCount", this.headerRowCount);
-            XmlHelper.WriteAttribute(sw, "insertRow", this.insertRow);
-            XmlHelper.WriteAttribute(sw, "insertRowShift", this.insertRowShift);
-            XmlHelper.WriteAttribute(sw, "totalsRowCount", this.totalsRowCount);
-            XmlHelper.WriteAttribute(sw, "totalsRowShown", this.totalsRowShown);
-            XmlHelper.WriteAttribute(sw, "published", this.published);
-            XmlHelper.WriteAttribute(sw, "headerRowDxfId", this.headerRowDxfId);
-            XmlHelper.WriteAttribute(sw, "dataDxfId", this.dataDxfId);
-            XmlHelper.WriteAttribute(sw, "totalsRowDxfId", this.totalsRowDxfId);
-            XmlHelper.WriteAttribute(sw, "headerRowBorderDxfId", this.headerRowBorderDxfId);
-            XmlHelper.WriteAttribute(sw, "tableBorderDxfId", this.tableBorderDxfId);
-            XmlHelper.WriteAttribute(sw, "totalsRowBorderDxfId", this.totalsRowBorderDxfId);
-            XmlHelper.WriteAttribute(sw, "headerRowCellStyle", this.headerRowCellStyle);
-            XmlHelper.WriteAttribute(sw, "dataCellStyle", this.dataCellStyle);
-            XmlHelper.WriteAttribute(sw, "totalsRowCellStyle", this.totalsRowCellStyle);
-            XmlHelper.WriteAttribute(sw, "connectionId", this.connectionId);
+            XmlHelper.WriteAttribute(sw, nameof(id), this.id);
+            XmlHelper.WriteAttribute(sw, nameof(name), this.name);
+            XmlHelper.WriteAttribute(sw, nameof(displayName), this.displayName);
+            XmlHelper.WriteAttribute(sw, nameof(comment), this.comment);
+            XmlHelper.WriteAttribute(sw, nameof(@ref), this.@ref);
+            XmlHelper.WriteAttribute(sw, nameof(tableType), this.tableType.ToString());
+            XmlHelper.WriteAttribute(sw, nameof(headerRowCount), this.headerRowCount);
+            XmlHelper.WriteAttribute(sw, nameof(insertRow), this.insertRow);
+            XmlHelper.WriteAttribute(sw, nameof(insertRowShift), this.insertRowShift);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowCount), this.totalsRowCount);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowShown), this.totalsRowShown);
+            XmlHelper.WriteAttribute(sw, nameof(published), this.published);
+            XmlHelper.WriteAttribute(sw, nameof(headerRowDxfId), this.headerRowDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(dataDxfId), this.dataDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowDxfId), this.totalsRowDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(headerRowBorderDxfId), this.headerRowBorderDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(tableBorderDxfId), this.tableBorderDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowBorderDxfId), this.totalsRowBorderDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(headerRowCellStyle), this.headerRowCellStyle);
+            XmlHelper.WriteAttribute(sw, nameof(dataCellStyle), this.dataCellStyle);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowCellStyle), this.totalsRowCellStyle);
+            XmlHelper.WriteAttribute(sw, nameof(connectionId), this.connectionId);
             sw.Write(">");
-            if (this.autoFilter != null)
-                this.autoFilter.Write(sw, "autoFilter");
-            if (this.sortState != null)
-                this.sortState.Write(sw, "sortState");
-            if (this.tableColumns != null)
-                this.tableColumns.Write(sw, "tableColumns");
-            if (this.tableStyleInfo != null)
-                this.tableStyleInfo.Write(sw, "tableStyleInfo");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
+            this.autoFilter?.Write(sw, nameof(autoFilter));
+            this.sortState?.Write(sw, nameof(sortState));
+            this.tableColumns?.Write(sw, nameof(tableColumns));
+            this.tableStyleInfo?.Write(sw, nameof(tableStyleInfo));
+            this.extLst?.Write(sw, nameof(extLst));
             sw.Write("</table>");
         }
 
         [XmlElement]
-        public CT_AutoFilter autoFilter
-        {
-            get
-            {
-                return this.autoFilterField;
-            }
-            set
-            {
-                this.autoFilterField = value;
-            }
-        }
+        public CT_AutoFilter autoFilter { get; set; }
         [XmlElement]
-        public CT_SortState sortState
-        {
-            get
-            {
-                return this.sortStateField;
-            }
-            set
-            {
-                this.sortStateField = value;
-            }
-        }
+        public CT_SortState sortState { get; set; }
         [XmlElement]
-        public CT_TableColumns tableColumns
-        {
-            get
-            {
-                return this.tableColumnsField;
-            }
-            set
-            {
-                this.tableColumnsField = value;
-            }
-        }
+        public CT_TableColumns tableColumns { get; set; }
         [XmlElement]
-        public CT_TableStyleInfo tableStyleInfo
-        {
-            get
-            {
-                return this.tableStyleInfoField;
-            }
-            set
-            {
-                this.tableStyleInfoField = value;
-            }
-        }
+        public CT_TableStyleInfo tableStyleInfo { get; set; }
         [XmlElement]
-        public CT_ExtensionList extLst
-        {
-            get
-            {
-                return this.extLstField;
-            }
-            set
-            {
-                this.extLstField = value;
-            }
-        }
+        public CT_ExtensionList extLst { get; set; }
         [XmlAttribute]
-        public uint id
-        {
-            get
-            {
-                return this.idField;
-            }
-            set
-            {
-                this.idField = value;
-            }
-        }
+        public uint id { get; set; }
         [XmlAttribute]
-        public string name
-        {
-            get
-            {
-                return this.nameField;
-            }
-            set
-            {
-                this.nameField = value;
-            }
-        }
+        public string name { get; set; }
         [XmlAttribute]
-        public string displayName
-        {
-            get
-            {
-                return this.displayNameField;
-            }
-            set
-            {
-                this.displayNameField = value;
-            }
-        }
+        public string displayName { get; set; }
         [XmlAttribute]
-        public string comment
-        {
-            get
-            {
-                return this.commentField;
-            }
-            set
-            {
-                this.commentField = value;
-            }
-        }
+        public string comment { get; set; }
         [XmlAttribute]
-        public string @ref
-        {
-            get
-            {
-                return this.refField;
-            }
-            set
-            {
-                this.refField = value;
-            }
-        }
+        public string @ref { get; set; }
         [XmlAttribute]
         [DefaultValue(ST_TableType.worksheet)]
-        public ST_TableType tableType
-        {
-            get
-            {
-                return this.tableTypeField;
-            }
-            set
-            {
-                this.tableTypeField = value;
-            }
-        }
+        public ST_TableType tableType { get; set; }
         [XmlAttribute]
         [DefaultValue(typeof(uint), "1")]
-        public uint headerRowCount
-        {
-            get
-            {
-                return this.headerRowCountField;
-            }
-            set
-            {
-                this.headerRowCountField = value;
-            }
-        }
+        public uint headerRowCount { get; set; }
         [XmlAttribute]
         [DefaultValue(false)]
-        public bool insertRow
-        {
-            get
-            {
-                return this.insertRowField;
-            }
-            set
-            {
-                this.insertRowField = value;
-            }
-        }
+        public bool insertRow { get; set; }
         [XmlAttribute]
         [DefaultValue(false)]
-        public bool insertRowShift
-        {
-            get
-            {
-                return this.insertRowShiftField;
-            }
-            set
-            {
-                this.insertRowShiftField = value;
-            }
-        }
+        public bool insertRowShift { get; set; }
         [XmlAttribute]
         [DefaultValue(typeof(uint), "0")]
-        public uint totalsRowCount
-        {
-            get
-            {
-                return this.totalsRowCountField;
-            }
-            set
-            {
-                this.totalsRowCountField = value;
-            }
-        }
+        public uint totalsRowCount { get; set; }
         [XmlAttribute]
         [DefaultValue(true)]
-        public bool totalsRowShown
-        {
-            get
-            {
-                return this.totalsRowShownField;
-            }
-            set
-            {
-                this.totalsRowShownField = value;
-            }
-        }
+        public bool totalsRowShown { get; set; }
         [XmlAttribute]
         [DefaultValue(false)]
-        public bool published
-        {
-            get
-            {
-                return this.publishedField;
-            }
-            set
-            {
-                this.publishedField = value;
-            }
-        }
+        public bool published { get; set; }
         [XmlAttribute]
-        public uint headerRowDxfId
-        {
-            get
-            {
-                return this.headerRowDxfIdField;
-            }
-            set
-            {
-                this.headerRowDxfIdField = value;
-            }
-        }
+        public uint headerRowDxfId { get; set; }
         [XmlIgnore]
-        public bool headerRowDxfIdSpecified
-        {
-            get
-            {
-                return this.headerRowDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.headerRowDxfIdFieldSpecified = value;
-            }
-        }
+        public bool headerRowDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint dataDxfId
-        {
-            get
-            {
-                return this.dataDxfIdField;
-            }
-            set
-            {
-                this.dataDxfIdField = value;
-            }
-        }
+        public uint dataDxfId { get; set; }
 
         [XmlIgnore]
-        public bool dataDxfIdSpecified
-        {
-            get
-            {
-                return this.dataDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.dataDxfIdFieldSpecified = value;
-            }
-        }
+        public bool dataDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint totalsRowDxfId
-        {
-            get
-            {
-                return this.totalsRowDxfIdField;
-            }
-            set
-            {
-                this.totalsRowDxfIdField = value;
-            }
-        }
+        public uint totalsRowDxfId { get; set; }
 
         [XmlIgnore]
-        public bool totalsRowDxfIdSpecified
-        {
-            get
-            {
-                return this.totalsRowDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.totalsRowDxfIdFieldSpecified = value;
-            }
-        }
+        public bool totalsRowDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint headerRowBorderDxfId
-        {
-            get
-            {
-                return this.headerRowBorderDxfIdField;
-            }
-            set
-            {
-                this.headerRowBorderDxfIdField = value;
-            }
-        }
+        public uint headerRowBorderDxfId { get; set; }
 
         [XmlIgnore]
-        public bool headerRowBorderDxfIdSpecified
-        {
-            get
-            {
-                return this.headerRowBorderDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.headerRowBorderDxfIdFieldSpecified = value;
-            }
-        }
+        public bool headerRowBorderDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint tableBorderDxfId
-        {
-            get
-            {
-                return this.tableBorderDxfIdField;
-            }
-            set
-            {
-                this.tableBorderDxfIdField = value;
-            }
-        }
+        public uint tableBorderDxfId { get; set; }
 
         [XmlIgnore]
-        public bool tableBorderDxfIdSpecified
-        {
-            get
-            {
-                return this.tableBorderDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.tableBorderDxfIdFieldSpecified = value;
-            }
-        }
+        public bool tableBorderDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint totalsRowBorderDxfId
-        {
-            get
-            {
-                return this.totalsRowBorderDxfIdField;
-            }
-            set
-            {
-                this.totalsRowBorderDxfIdField = value;
-            }
-        }
+        public uint totalsRowBorderDxfId { get; set; }
 
         [XmlIgnore]
-        public bool totalsRowBorderDxfIdSpecified
-        {
-            get
-            {
-                return this.totalsRowBorderDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.totalsRowBorderDxfIdFieldSpecified = value;
-            }
-        }
+        public bool totalsRowBorderDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public string headerRowCellStyle
-        {
-            get
-            {
-                return this.headerRowCellStyleField;
-            }
-            set
-            {
-                this.headerRowCellStyleField = value;
-            }
-        }
+        public string headerRowCellStyle { get; set; }
         [XmlAttribute]
-        public string dataCellStyle
-        {
-            get
-            {
-                return this.dataCellStyleField;
-            }
-            set
-            {
-                this.dataCellStyleField = value;
-            }
-        }
+        public string dataCellStyle { get; set; }
         [XmlAttribute]
-        public string totalsRowCellStyle
-        {
-            get
-            {
-                return this.totalsRowCellStyleField;
-            }
-            set
-            {
-                this.totalsRowCellStyleField = value;
-            }
-        }
+        public string totalsRowCellStyle { get; set; }
         [XmlAttribute]
-        public uint connectionId
-        {
-            get
-            {
-                return this.connectionIdField;
-            }
-            set
-            {
-                this.connectionIdField = value;
-            }
-        }
+        public uint connectionId { get; set; }
 
         [XmlIgnore]
-        public bool connectionIdSpecified
-        {
-            get
-            {
-                return this.connectionIdFieldSpecified;
-            }
-            set
-            {
-                this.connectionIdFieldSpecified = value;
-            }
-        }
+        public bool connectionIdSpecified { get; set; }
     }
     [Serializable]
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_TableColumns
     {
-
-        private List<CT_TableColumn> tableColumnField;
-
-        private uint countField;
-
-        private bool countFieldSpecified;
-
         public CT_TableColumns()
         {
             //this.tableColumnField = new List<CT_TableColumn>();
@@ -643,12 +223,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_TableColumns ctObj = new CT_TableColumns();
-            if (node.Attributes["count"] != null)
-                ctObj.count = XmlHelper.ReadUInt(node.Attributes["count"]);
+            if (node.Attributes[nameof(count)] != null)
+                ctObj.count = XmlHelper.ReadUInt(node.Attributes[nameof(count)]);
             ctObj.tableColumn = new List<CT_TableColumn>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "tableColumn")
+                if (childNode.LocalName == nameof(tableColumn))
                     ctObj.tableColumn.Add(CT_TableColumn.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -658,100 +238,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "count", this.count);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(count), this.count);
             sw.Write(">");
-            if (this.tableColumn != null)
-            {
-                foreach (CT_TableColumn x in this.tableColumn)
-                {
-                    x.Write(sw, "tableColumn");
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
+            tableColumn?.ForEach(x => x.Write(sw, nameof(tableColumn)));
+            sw.Write($"</{nodeName}>");
         }
 
         [XmlElement]
-        public List<CT_TableColumn> tableColumn
-        {
-            get
-            {
-                return this.tableColumnField;
-            }
-            set
-            {
-                this.tableColumnField = value;
-            }
-        }
+        public List<CT_TableColumn> tableColumn { get; set; }
         [XmlAttribute]
-        public uint count
-        {
-            get
-            {
-                return this.countField;
-            }
-            set
-            {
-                this.countField = value;
-            }
-        }
+        public uint count { get; set; }
 
         [XmlIgnore]
-        public bool countSpecified
-        {
-            get
-            {
-                return this.countFieldSpecified;
-            }
-            set
-            {
-                this.countFieldSpecified = value;
-            }
-        }
+        public bool countSpecified { get; set; }
     }
     [Serializable]
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_TableColumn
     {
-
-        private CT_TableFormula calculatedColumnFormulaField;
-
-        private CT_TableFormula totalsRowFormulaField;
-
-        private CT_XmlColumnPr xmlColumnPrField;
-
-        private CT_ExtensionList extLstField;
-
-        private uint idField;
-
-        private string uniqueNameField;
-
-        private string nameField;
-
-        private ST_TotalsRowFunction totalsRowFunctionField;
-
-        private string totalsRowLabelField;
-
-        private uint queryTableFieldIdField;
-
-        private bool queryTableFieldIdFieldSpecified;
-
-        private uint headerRowDxfIdField;
-
-        private bool headerRowDxfIdFieldSpecified;
-
-        private uint dataDxfIdField;
-
-        private bool dataDxfIdFieldSpecified;
-
-        private uint totalsRowDxfIdField;
-
-        private bool totalsRowDxfIdFieldSpecified;
-
-        private string headerRowCellStyleField;
-
-        private string dataCellStyleField;
-
         private string totalsRowCellStyleField;
 
         public CT_TableColumn()
@@ -760,40 +265,40 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             //this.xmlColumnPrField = new CT_XmlColumnPr();
             //this.totalsRowFormulaField = new CT_TableFormula();
             //this.calculatedColumnFormulaField = new CT_TableFormula();
-            this.totalsRowFunctionField = ST_TotalsRowFunction.none;
+            this.totalsRowFunction = ST_TotalsRowFunction.none;
         }
         public static CT_TableColumn Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
             CT_TableColumn ctObj = new CT_TableColumn();
-            if (node.Attributes["id"] != null)
-                ctObj.id = XmlHelper.ReadUInt(node.Attributes["id"]);
-            ctObj.uniqueName = XmlHelper.ReadString(node.Attributes["uniqueName"]);
-            ctObj.name = XmlHelper.ReadString(node.Attributes["name"]);
-            if (node.Attributes["totalsRowFunction"] != null)
-                ctObj.totalsRowFunction = (ST_TotalsRowFunction)Enum.Parse(typeof(ST_TotalsRowFunction), node.Attributes["totalsRowFunction"].Value);
-            ctObj.totalsRowLabel = XmlHelper.ReadString(node.Attributes["totalsRowLabel"]);
-            if (node.Attributes["queryTableFieldId"] != null)
-                ctObj.queryTableFieldId = XmlHelper.ReadUInt(node.Attributes["queryTableFieldId"]);
-            if (node.Attributes["headerRowDxfId"] != null)
-                ctObj.headerRowDxfId = XmlHelper.ReadUInt(node.Attributes["headerRowDxfId"]);
-            if (node.Attributes["dataDxfId"] != null)
-                ctObj.dataDxfId = XmlHelper.ReadUInt(node.Attributes["dataDxfId"]);
-            if (node.Attributes["totalsRowDxfId"] != null)
-                ctObj.totalsRowDxfId = XmlHelper.ReadUInt(node.Attributes["totalsRowDxfId"]);
-            ctObj.headerRowCellStyle = XmlHelper.ReadString(node.Attributes["headerRowCellStyle"]);
-            ctObj.dataCellStyle = XmlHelper.ReadString(node.Attributes["dataCellStyle"]);
-            ctObj.totalsRowCellStyle = XmlHelper.ReadString(node.Attributes["totalsRowCellStyle"]);
+            if (node.Attributes[nameof(id)] != null)
+                ctObj.id = XmlHelper.ReadUInt(node.Attributes[nameof(id)]);
+            ctObj.uniqueName = XmlHelper.ReadString(node.Attributes[nameof(uniqueName)]);
+            ctObj.name = XmlHelper.ReadString(node.Attributes[nameof(name)]);
+            if (node.Attributes[nameof(totalsRowFunction)] != null)
+                ctObj.totalsRowFunction = (ST_TotalsRowFunction)Enum.Parse(typeof(ST_TotalsRowFunction), node.Attributes[nameof(totalsRowFunction)].Value);
+            ctObj.totalsRowLabel = XmlHelper.ReadString(node.Attributes[nameof(totalsRowLabel)]);
+            if (node.Attributes[nameof(queryTableFieldId)] != null)
+                ctObj.queryTableFieldId = XmlHelper.ReadUInt(node.Attributes[nameof(queryTableFieldId)]);
+            if (node.Attributes[nameof(headerRowDxfId)] != null)
+                ctObj.headerRowDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(headerRowDxfId)]);
+            if (node.Attributes[nameof(dataDxfId)] != null)
+                ctObj.dataDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(dataDxfId)]);
+            if (node.Attributes[nameof(totalsRowDxfId)] != null)
+                ctObj.totalsRowDxfId = XmlHelper.ReadUInt(node.Attributes[nameof(totalsRowDxfId)]);
+            ctObj.headerRowCellStyle = XmlHelper.ReadString(node.Attributes[nameof(headerRowCellStyle)]);
+            ctObj.dataCellStyle = XmlHelper.ReadString(node.Attributes[nameof(dataCellStyle)]);
+            ctObj.totalsRowCellStyle = XmlHelper.ReadString(node.Attributes[nameof(totalsRowCellStyle)]);
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "calculatedColumnFormula")
+                if (childNode.LocalName == nameof(calculatedColumnFormula))
                     ctObj.calculatedColumnFormula = CT_TableFormula.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "totalsRowFormula")
+                else if (childNode.LocalName == nameof(totalsRowFormula))
                     ctObj.totalsRowFormula = CT_TableFormula.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "xmlColumnPr")
+                else if (childNode.LocalName == nameof(xmlColumnPr))
                     ctObj.xmlColumnPr = CT_XmlColumnPr.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "extLst")
+                else if (childNode.LocalName == nameof(extLst))
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
             }
             return ctObj;
@@ -803,263 +308,69 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "id", this.id);
-            XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName);
-            XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "totalsRowFunction", this.totalsRowFunction.ToString());
-            XmlHelper.WriteAttribute(sw, "totalsRowLabel", this.totalsRowLabel);
-            XmlHelper.WriteAttribute(sw, "queryTableFieldId", this.queryTableFieldId);
-            XmlHelper.WriteAttribute(sw, "headerRowDxfId", this.headerRowDxfId);
-            XmlHelper.WriteAttribute(sw, "dataDxfId", this.dataDxfId);
-            XmlHelper.WriteAttribute(sw, "totalsRowDxfId", this.totalsRowDxfId);
-            XmlHelper.WriteAttribute(sw, "headerRowCellStyle", this.headerRowCellStyle);
-            XmlHelper.WriteAttribute(sw, "dataCellStyle", this.dataCellStyle);
-            XmlHelper.WriteAttribute(sw, "totalsRowCellStyle", this.totalsRowCellStyle);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(id), this.id);
+            XmlHelper.WriteAttribute(sw, nameof(uniqueName), this.uniqueName);
+            XmlHelper.WriteAttribute(sw, nameof(name), this.name);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowFunction), this.totalsRowFunction.ToString());
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowLabel), this.totalsRowLabel);
+            XmlHelper.WriteAttribute(sw, nameof(queryTableFieldId), this.queryTableFieldId);
+            XmlHelper.WriteAttribute(sw, nameof(headerRowDxfId), this.headerRowDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(dataDxfId), this.dataDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowDxfId), this.totalsRowDxfId);
+            XmlHelper.WriteAttribute(sw, nameof(headerRowCellStyle), this.headerRowCellStyle);
+            XmlHelper.WriteAttribute(sw, nameof(dataCellStyle), this.dataCellStyle);
+            XmlHelper.WriteAttribute(sw, nameof(totalsRowCellStyle), this.totalsRowCellStyle);
             sw.Write(">");
-            if (this.calculatedColumnFormula != null)
-                this.calculatedColumnFormula.Write(sw, "calculatedColumnFormula");
-            if (this.totalsRowFormula != null)
-                this.totalsRowFormula.Write(sw, "totalsRowFormula");
-            if (this.xmlColumnPr != null)
-                this.xmlColumnPr.Write(sw, "xmlColumnPr");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            this.calculatedColumnFormula?.Write(sw, nameof(calculatedColumnFormula));
+            this.totalsRowFormula?.Write(sw, nameof(totalsRowFormula));
+            this.xmlColumnPr?.Write(sw, nameof(xmlColumnPr));
+            this.extLst?.Write(sw, nameof(extLst));
+            sw.Write($"</{nodeName}>");
         }
 
         [XmlElement]
-        public CT_TableFormula calculatedColumnFormula
-        {
-            get
-            {
-                return this.calculatedColumnFormulaField;
-            }
-            set
-            {
-                this.calculatedColumnFormulaField = value;
-            }
-        }
+        public CT_TableFormula calculatedColumnFormula { get; set; }
         [XmlElement]
-        public CT_TableFormula totalsRowFormula
-        {
-            get
-            {
-                return this.totalsRowFormulaField;
-            }
-            set
-            {
-                this.totalsRowFormulaField = value;
-            }
-        }
-        public CT_XmlColumnPr xmlColumnPr
-        {
-            get
-            {
-                return this.xmlColumnPrField;
-            }
-            set
-            {
-                this.xmlColumnPrField = value;
-            }
-        }
+        public CT_TableFormula totalsRowFormula { get; set; }
+        public CT_XmlColumnPr xmlColumnPr { get; set; }
         [XmlElement]
-        public CT_ExtensionList extLst
-        {
-            get
-            {
-                return this.extLstField;
-            }
-            set
-            {
-                this.extLstField = value;
-            }
-        }
+        public CT_ExtensionList extLst { get; set; }
         [XmlAttribute]
-        public uint id
-        {
-            get
-            {
-                return this.idField;
-            }
-            set
-            {
-                this.idField = value;
-            }
-        }
+        public uint id { get; set; }
         [XmlAttribute]
-        public string uniqueName
-        {
-            get
-            {
-                return this.uniqueNameField;
-            }
-            set
-            {
-                this.uniqueNameField = value;
-            }
-        }
+        public string uniqueName { get; set; }
         [XmlAttribute]
-        public string name
-        {
-            get
-            {
-                return this.nameField;
-            }
-            set
-            {
-                this.nameField = value;
-            }
-        }
+        public string name { get; set; }
         [XmlAttribute]
         [DefaultValue(ST_TotalsRowFunction.none)]
-        public ST_TotalsRowFunction totalsRowFunction
-        {
-            get
-            {
-                return this.totalsRowFunctionField;
-            }
-            set
-            {
-                this.totalsRowFunctionField = value;
-            }
-        }
+        public ST_TotalsRowFunction totalsRowFunction { get; set; }
         [XmlAttribute]
-        public string totalsRowLabel
-        {
-            get
-            {
-                return this.totalsRowLabelField;
-            }
-            set
-            {
-                this.totalsRowLabelField = value;
-            }
-        }
+        public string totalsRowLabel { get; set; }
         [XmlAttribute]
-        public uint queryTableFieldId
-        {
-            get
-            {
-                return this.queryTableFieldIdField;
-            }
-            set
-            {
-                this.queryTableFieldIdField = value;
-            }
-        }
+        public uint queryTableFieldId { get; set; }
 
         [XmlIgnore]
-        public bool queryTableFieldIdSpecified
-        {
-            get
-            {
-                return this.queryTableFieldIdFieldSpecified;
-            }
-            set
-            {
-                this.queryTableFieldIdFieldSpecified = value;
-            }
-        }
+        public bool queryTableFieldIdSpecified { get; set; }
         [XmlAttribute]
-        public uint headerRowDxfId
-        {
-            get
-            {
-                return this.headerRowDxfIdField;
-            }
-            set
-            {
-                this.headerRowDxfIdField = value;
-            }
-        }
+        public uint headerRowDxfId { get; set; }
 
         [XmlIgnore]
-        public bool headerRowDxfIdSpecified
-        {
-            get
-            {
-                return this.headerRowDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.headerRowDxfIdFieldSpecified = value;
-            }
-        }
+        public bool headerRowDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint dataDxfId
-        {
-            get
-            {
-                return this.dataDxfIdField;
-            }
-            set
-            {
-                this.dataDxfIdField = value;
-            }
-        }
+        public uint dataDxfId { get; set; }
 
         [XmlIgnore]
-        public bool dataDxfIdSpecified
-        {
-            get
-            {
-                return this.dataDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.dataDxfIdFieldSpecified = value;
-            }
-        }
+        public bool dataDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public uint totalsRowDxfId
-        {
-            get
-            {
-                return this.totalsRowDxfIdField;
-            }
-            set
-            {
-                this.totalsRowDxfIdField = value;
-            }
-        }
+        public uint totalsRowDxfId { get; set; }
 
         [XmlIgnore]
-        public bool totalsRowDxfIdSpecified
-        {
-            get
-            {
-                return this.totalsRowDxfIdFieldSpecified;
-            }
-            set
-            {
-                this.totalsRowDxfIdFieldSpecified = value;
-            }
-        }
+        public bool totalsRowDxfIdSpecified { get; set; }
         [XmlAttribute]
-        public string headerRowCellStyle
-        {
-            get
-            {
-                return this.headerRowCellStyleField;
-            }
-            set
-            {
-                this.headerRowCellStyleField = value;
-            }
-        }
+        public string headerRowCellStyle { get; set; }
         [XmlAttribute]
-        public string dataCellStyle
-        {
-            get
-            {
-                return this.dataCellStyleField;
-            }
-            set
-            {
-                this.dataCellStyleField = value;
-            }
-        }
+        public string dataCellStyle { get; set; }
         [XmlAttribute]
         public string totalsRowCellStyle
         {
@@ -1077,49 +388,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_TableFormula
     {
-
-        private bool arrayField;
-
-        private string valueField;
-
         public CT_TableFormula()
         {
-            this.arrayField = false;
+            this.array = false;
         }
         [XmlAttribute]
         [DefaultValue(false)]
-        public bool array
-        {
-            get
-            {
-                return this.arrayField;
-            }
-            set
-            {
-                this.arrayField = value;
-            }
-        }
+        public bool array { get; set; }
 
         [XmlText]
-        public string Value
-        {
-            get
-            {
-                return this.valueField;
-            }
-            set
-            {
-                this.valueField = value;
-            }
-        }
+        public string Value { get; set; }
 
         public static CT_TableFormula Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
                 return null;
             CT_TableFormula ctObj = new CT_TableFormula();
-            if (node.Attributes["array"] != null)
-                ctObj.array = XmlHelper.ReadBool(node.Attributes["array"]);
+            if (node.Attributes[nameof(array)] != null)
+                ctObj.array = XmlHelper.ReadBool(node.Attributes[nameof(array)]);
             ctObj.Value = node.InnerText;
             return ctObj;
         }
@@ -1128,11 +414,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "array", this.array);
+            sw.Write($"<{nodeName}");
+            XmlHelper.WriteAttribute(sw, nameof(array), this.array);
             sw.Write(">");
-            sw.Write(XmlHelper.EncodeXml(this.valueField));
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write(XmlHelper.EncodeXml(this.Value));
+            sw.Write($"</{nodeName}>");
         }
 
     }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Worksheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Worksheet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -15,82 +16,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         IsNullable = false)]
     public class CT_Worksheet
     {
-        // all the class attributes are XML elements. All except sheetData are optional.
-        private CT_SheetPr sheetPrField = null;
-
-        private CT_SheetDimension dimensionField = null;
-
-        private CT_SheetViews sheetViewsField = null;
-
-        private CT_SheetFormatPr sheetFormatPrField = null;
-
-        private List<CT_Cols> colsField = new List<CT_Cols>();
-
-        private CT_SheetData sheetDataField = new CT_SheetData();
-
-        private CT_SheetCalcPr sheetCalcPrField = null;
-
-        private CT_SheetProtection sheetProtectionField = null;
-
-        private CT_ProtectedRanges protectedRangesField = null;
-
-        private CT_Scenarios scenariosField = null;
-
-        private CT_AutoFilter autoFilterField = null;
-
-        private CT_SortState sortStateField = null;
-
-        private CT_DataConsolidate dataConsolidateField = null;
-
-        private CT_CustomSheetViews customSheetViewsField = null;
-
-        private CT_MergeCells mergeCellsField = null;
-
-        private CT_PhoneticPr phoneticPrField = null;
-
         private List<CT_ConditionalFormatting> conditionalFormattingField = null;
-
-        private CT_DataValidations dataValidationsField = null;
-
-        private CT_Hyperlinks hyperlinksField = null;
-
-        private CT_PrintOptions printOptionsField = null;
-
-        private CT_PageMargins pageMarginsField = null;
-
-        private CT_PageSetup pageSetupField = null;
-
-        private CT_HeaderFooter headerFooterField = null;
-
-        private CT_PageBreak rowBreaksField = null;
-
-        private CT_PageBreak colBreaksField = null;
-
-        private CT_CustomProperties customPropertiesField = null;
-
-        private CT_CellWatches cellWatchesField = null;
-
-        private CT_IgnoredErrors ignoredErrorsField = null;
-
-        private CT_CellSmartTags smartTagsField = null;
-
-        private CT_Drawing drawingField = null;
-
-        private CT_LegacyDrawing legacyDrawingField = null;
-
-        private CT_LegacyDrawing legacyDrawingHFField = null;
-
-        private CT_SheetBackgroundPicture pictureField = null;
-
-        private CT_OleObjects oleObjectsField = null;
-
-        private CT_Controls controlsField = null;
-
-        private CT_WebPublishItems webPublishItemsField = null;
-
-        private CT_TableParts tablePartsField = null;
-
-        private CT_ExtensionList extLstField = null;
 
         public static CT_Worksheet Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
@@ -101,81 +27,81 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.conditionalFormatting = new List<CT_ConditionalFormatting>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
-                if (childNode.LocalName == "sheetPr")
+                if (childNode.LocalName == nameof(sheetPr))
                     ctObj.sheetPr = CT_SheetPr.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "dimension")
+                else if (childNode.LocalName == nameof(dimension))
                     ctObj.dimension = CT_SheetDimension.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sheetViews")
+                else if (childNode.LocalName == nameof(sheetViews))
                     ctObj.sheetViews = CT_SheetViews.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sheetFormatPr")
+                else if (childNode.LocalName == nameof(sheetFormatPr))
                     ctObj.sheetFormatPr = CT_SheetFormatPr.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sheetData")
+                else if (childNode.LocalName == nameof(sheetData))
                     ctObj.sheetData = CT_SheetData.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sheetCalcPr")
+                else if (childNode.LocalName == nameof(sheetCalcPr))
                     ctObj.sheetCalcPr = CT_SheetCalcPr.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sheetProtection")
+                else if (childNode.LocalName == nameof(sheetProtection))
                     ctObj.sheetProtection = CT_SheetProtection.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "protectedRanges")
+                else if (childNode.LocalName == nameof(protectedRanges))
                     ctObj.protectedRanges = CT_ProtectedRanges.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "scenarios")
+                else if (childNode.LocalName == nameof(scenarios))
                     ctObj.scenarios = CT_Scenarios.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "autoFilter")
+                else if (childNode.LocalName == nameof(autoFilter))
                     ctObj.autoFilter = CT_AutoFilter.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "sortState")
+                else if (childNode.LocalName == nameof(sortState))
                     ctObj.sortState = CT_SortState.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "dataConsolidate")
+                else if (childNode.LocalName == nameof(dataConsolidate))
                     ctObj.dataConsolidate = CT_DataConsolidate.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "customSheetViews")
+                else if (childNode.LocalName == nameof(customSheetViews))
                     ctObj.customSheetViews = CT_CustomSheetViews.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "mergeCells")
+                else if (childNode.LocalName == nameof(mergeCells))
                     ctObj.mergeCells = CT_MergeCells.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "phoneticPr")
+                else if (childNode.LocalName == nameof(phoneticPr))
                     ctObj.phoneticPr = CT_PhoneticPr.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "dataValidations")
+                else if (childNode.LocalName == nameof(dataValidations))
                     ctObj.dataValidations = CT_DataValidations.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "hyperlinks")
+                else if (childNode.LocalName == nameof(hyperlinks))
                     ctObj.hyperlinks = CT_Hyperlinks.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "printOptions")
+                else if (childNode.LocalName == nameof(printOptions))
                     ctObj.printOptions = CT_PrintOptions.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "pageMargins")
+                else if (childNode.LocalName == nameof(pageMargins))
                     ctObj.pageMargins = CT_PageMargins.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "pageSetup")
+                else if (childNode.LocalName == nameof(pageSetup))
                     ctObj.pageSetup = CT_PageSetup.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "headerFooter")
+                else if (childNode.LocalName == nameof(headerFooter))
                     ctObj.headerFooter = CT_HeaderFooter.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "rowBreaks")
+                else if (childNode.LocalName == nameof(rowBreaks))
                     ctObj.rowBreaks = CT_PageBreak.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "colBreaks")
+                else if (childNode.LocalName == nameof(colBreaks))
                     ctObj.colBreaks = CT_PageBreak.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "customProperties")
+                else if (childNode.LocalName == nameof(customProperties))
                     ctObj.customProperties = CT_CustomProperties.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "cellWatches")
+                else if (childNode.LocalName == nameof(cellWatches))
                     ctObj.cellWatches = CT_CellWatches.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "ignoredErrors")
+                else if (childNode.LocalName == nameof(ignoredErrors))
                     ctObj.ignoredErrors = CT_IgnoredErrors.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "smartTags")
+                else if (childNode.LocalName == nameof(smartTags))
                     ctObj.smartTags = CT_CellSmartTags.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "drawing")
+                else if (childNode.LocalName == nameof(drawing))
                     ctObj.drawing = CT_Drawing.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "legacyDrawing")
+                else if (childNode.LocalName == nameof(legacyDrawing))
                     ctObj.legacyDrawing = CT_LegacyDrawing.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "legacyDrawingHF")
+                else if (childNode.LocalName == nameof(legacyDrawingHF))
                     ctObj.legacyDrawingHF = CT_LegacyDrawing.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "picture")
+                else if (childNode.LocalName == nameof(picture))
                     ctObj.picture = CT_SheetBackgroundPicture.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "oleObjects")
+                else if (childNode.LocalName == nameof(oleObjects))
                     ctObj.oleObjects = CT_OleObjects.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "controls")
+                else if (childNode.LocalName == nameof(controls))
                     ctObj.controls = CT_Controls.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "webPublishItems")
+                else if (childNode.LocalName == nameof(webPublishItems))
                     ctObj.webPublishItems = CT_WebPublishItems.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "tableParts")
+                else if (childNode.LocalName == nameof(tableParts))
                     ctObj.tableParts = CT_TableParts.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "extLst")
+                else if (childNode.LocalName == nameof(extLst))
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "cols")
+                else if (childNode.LocalName == nameof(cols))
                     ctObj.cols.Add(CT_Cols.Parse(childNode, namespaceManager));
-                else if (childNode.LocalName == "conditionalFormatting")
+                else if (childNode.LocalName == nameof(conditionalFormatting))
                     ctObj.conditionalFormatting.Add(CT_ConditionalFormatting.Parse(childNode, namespaceManager));
             }
             return ctObj;
@@ -189,109 +115,61 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             {
                 sw.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
                 sw.Write("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
-                if (this.sheetPr != null)
-                    this.sheetPr.Write(sw, "sheetPr");
-                if (this.dimension != null)
-                    this.dimension.Write(sw, "dimension");
-                if (this.sheetViews != null)
-                    this.sheetViews.Write(sw, "sheetViews");
-                if (this.sheetFormatPr != null)
-                    this.sheetFormatPr.Write(sw, "sheetFormatPr");
-                if (this.cols != null)
-                {
-                    foreach (CT_Cols x in this.cols)
-                    {
-                        x.Write(sw, "cols");
-                    }
-                }
-                if (this.sheetData != null)
-                    this.sheetData.Write(sw, "sheetData");
-                if (this.sheetCalcPr != null)
-                    this.sheetCalcPr.Write(sw, "sheetCalcPr");
-                if (this.sheetProtection != null)
-                    this.sheetProtection.Write(sw, "sheetProtection");
-                if (this.protectedRanges != null)
-                    this.protectedRanges.Write(sw, "protectedRanges");
-                if (this.scenarios != null)
-                    this.scenarios.Write(sw, "scenarios");
-                if (this.autoFilter != null)
-                    this.autoFilter.Write(sw, "autoFilter");
-                if (this.sortState != null)
-                    this.sortState.Write(sw, "sortState");
-                if (this.dataConsolidate != null)
-                    this.dataConsolidate.Write(sw, "dataConsolidate");
-                if (this.customSheetViews != null)
-                    this.customSheetViews.Write(sw, "customSheetViews");
-                if (this.mergeCells != null)
-                    this.mergeCells.Write(sw, "mergeCells");
-                if (this.phoneticPr != null)
-                    this.phoneticPr.Write(sw, "phoneticPr");
-                if (this.conditionalFormatting != null)
-                {
-                    foreach (CT_ConditionalFormatting x in this.conditionalFormatting)
-                    {
-                        x.Write(sw, "conditionalFormatting");
-                    }
-                }
-                if (this.dataValidations != null)
-                    this.dataValidations.Write(sw, "dataValidations");
-                if (this.hyperlinks != null)
-                    this.hyperlinks.Write(sw, "hyperlinks");
-                if (this.printOptions != null)
-                    this.printOptions.Write(sw, "printOptions");
-                if (this.pageMargins != null)
-                    this.pageMargins.Write(sw, "pageMargins");
-                if (this.pageSetup != null)
-                    this.pageSetup.Write(sw, "pageSetup");
-                if (this.headerFooter != null)
-                    this.headerFooter.Write(sw, "headerFooter");
-                if (this.rowBreaks != null)
-                    this.rowBreaks.Write(sw, "rowBreaks");
-                if (this.colBreaks != null)
-                    this.colBreaks.Write(sw, "colBreaks");
-                if (this.customProperties != null)
-                    this.customProperties.Write(sw, "customProperties");
-                if (this.cellWatches != null)
-                    this.cellWatches.Write(sw, "cellWatches");
-                if (this.ignoredErrors != null)
-                    this.ignoredErrors.Write(sw, "ignoredErrors");
-                if (this.smartTags != null)
-                    this.smartTags.Write(sw, "smartTags");
-                if (this.drawing != null)
-                    this.drawing.Write(sw, "drawing");
-                if (this.legacyDrawing != null)
-                    this.legacyDrawing.Write(sw, "legacyDrawing");
-                if (this.legacyDrawingHF != null)
-                    this.legacyDrawingHF.Write(sw, "legacyDrawingHF");
-                if (this.picture != null)
-                    this.picture.Write(sw, "picture");
-                if (this.oleObjects != null)
-                    this.oleObjects.Write(sw, "oleObjects");
-                if (this.controls != null)
-                    this.controls.Write(sw, "controls");
-                if (this.webPublishItems != null)
-                    this.webPublishItems.Write(sw, "webPublishItems");
-                if (this.tableParts != null)
-                    this.tableParts.Write(sw, "tableParts");
-                if (this.extLst != null)
-                    this.extLst.Write(sw, "extLst");
+                this.sheetPr?.Write(sw, nameof(sheetPr));
+                this.dimension?.Write(sw, nameof(dimension));
+                this.sheetViews?.Write(sw, nameof(sheetViews));
+                this.sheetFormatPr?.Write(sw, nameof(sheetFormatPr));
+                this.cols?.ForEach(x => x.Write(sw, nameof(cols)));
+                this.sheetData?.Write(sw, nameof(sheetData));
+                this.sheetCalcPr?.Write(sw, nameof(sheetCalcPr));
+                this.sheetProtection?.Write(sw, nameof(sheetProtection));
+                this.protectedRanges?.Write(sw, nameof(protectedRanges));
+                this.scenarios?.Write(sw, nameof(scenarios));
+                this.autoFilter?.Write(sw, nameof(autoFilter));
+                this.sortState?.Write(sw, nameof(sortState));
+                this.dataConsolidate?.Write(sw, nameof(dataConsolidate));
+                this.customSheetViews?.Write(sw, nameof(customSheetViews));
+                this.mergeCells?.Write(sw, nameof(mergeCells));
+                this.phoneticPr?.Write(sw, nameof(phoneticPr));
+                this.conditionalFormatting?.ForEach(x => x.Write(sw, nameof(conditionalFormatting)));
+                this.dataValidations?.Write(sw, nameof(dataValidations));
+                this.hyperlinks?.Write(sw, nameof(hyperlinks));
+                this.printOptions?.Write(sw, nameof(printOptions));
+                this.pageMargins?.Write(sw, nameof(pageMargins));
+                this.pageSetup?.Write(sw, nameof(pageSetup));
+                this.headerFooter?.Write(sw, nameof(headerFooter));
+                this.rowBreaks?.Write(sw, nameof(rowBreaks));
+                this.colBreaks?.Write(sw, nameof(colBreaks));
+                this.customProperties?.Write(sw, nameof(customProperties));
+                this.cellWatches?.Write(sw, nameof(cellWatches));
+                this.ignoredErrors?.Write(sw, nameof(ignoredErrors));
+                this.smartTags?.Write(sw, nameof(smartTags));
+                this.drawing?.Write(sw, nameof(drawing));
+                this.legacyDrawing?.Write(sw, nameof(legacyDrawing));
+                this.legacyDrawingHF?.Write(sw, nameof(legacyDrawingHF));
+                this.picture?.Write(sw, nameof(picture));
+                this.oleObjects?.Write(sw, nameof(oleObjects));
+                this.controls?.Write(sw, nameof(controls));
+                this.webPublishItems?.Write(sw, nameof(webPublishItems));
+                this.tableParts?.Write(sw, nameof(tableParts));
+                this.extLst?.Write(sw, nameof(extLst));
                 sw.Write("</worksheet>");
             }
         }
 
         public CT_AutoFilter AddNewAutoFilter()
         {
-            this.autoFilterField = new CT_AutoFilter();
-            return this.autoFilterField;
+            this.autoFilter = new CT_AutoFilter();
+            return this.autoFilter;
         }
         public bool IsSetRowBreaks()
         {
-            return this.rowBreaksField != null;
+            return this.rowBreaks != null;
         }
         public CT_Drawing AddNewDrawing()
         {
-            this.drawingField = new CT_Drawing();
-            return drawingField;
+            this.drawing = new CT_Drawing();
+            return drawing;
         }
         public CT_LegacyDrawing AddNewLegacyDrawing()
         {
@@ -300,45 +178,45 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public CT_PageBreak AddNewRowBreaks()
         {
-            this.rowBreaksField = new CT_PageBreak();
-            return this.rowBreaksField;
+            this.rowBreaks = new CT_PageBreak();
+            return this.rowBreaks;
         }
         public CT_PageBreak AddNewColBreaks()
         {
-            this.colBreaksField = new CT_PageBreak();
-            return this.colBreaksField;
+            this.colBreaks = new CT_PageBreak();
+            return this.colBreaks;
         }
         public bool IsSetSheetFormatPr()
         {
-            return this.sheetFormatPrField != null;
+            return this.sheetFormatPr != null;
         }
         public bool IsSetPrintOptions()
         {
-            return this.printOptionsField != null;
+            return this.printOptions != null;
         }
         public void UnsetMergeCells()
         {
-            this.mergeCellsField = null;
+            this.mergeCells = null;
         }
         public CT_PrintOptions AddNewPrintOptions()
         {
-            this.printOptionsField = new CT_PrintOptions();
-            return this.printOptionsField;
+            this.printOptions = new CT_PrintOptions();
+            return this.printOptions;
         }
         public CT_DataValidations AddNewDataValidations()
         {
-            this.dataValidationsField = new CT_DataValidations();
-            return this.dataValidationsField;
+            this.dataValidations = new CT_DataValidations();
+            return this.dataValidations;
         }
         public CT_SheetViews AddNewSheetViews()
         {
-            this.sheetViewsField = new CT_SheetViews();
-            return this.sheetViewsField;
+            this.sheetViews = new CT_SheetViews();
+            return this.sheetViews;
         }
         public CT_Hyperlinks AddNewHyperlinks()
         {
-            this.hyperlinksField = new CT_Hyperlinks();
-            return this.hyperlinksField;
+            this.hyperlinks = new CT_Hyperlinks();
+            return this.hyperlinks;
         }
         public CT_ConditionalFormatting AddNewConditionalFormatting()
         {
@@ -349,367 +227,208 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public CT_ConditionalFormatting GetConditionalFormattingArray(int index)
         {
-            return (null == conditionalFormattingField) ? null : this.conditionalFormattingField[index];
+            return this.conditionalFormattingField?[index];
         }
         public CT_MergeCells AddNewMergeCells()
         {
-            this.mergeCellsField = new CT_MergeCells();
-            return this.mergeCellsField;
+            this.mergeCells = new CT_MergeCells();
+            return this.mergeCells;
         }
         public bool IsSetColBreaks()
         {
-            return this.colBreaksField != null;
+            return this.colBreaks != null;
         }
         public bool IsSetHyperlinks()
         {
-            return this.hyperlinksField != null;
+            return this.hyperlinks != null;
         }
         public bool IsSetMergeCells()
         {
-            return this.mergeCellsField != null;
+            return this.mergeCells != null;
         }
         public bool IsSetSheetProtection()
         {
-            return this.sheetProtectionField != null;
+            return this.sheetProtection != null;
         }
         public bool IsSetDrawing()
         {
-            return this.drawingField != null;
+            return this.drawing != null;
         }
         public void UnsetDrawing()
         {
-            this.drawingField = null;
+            this.drawing = null;
         }
         public bool IsSetLegacyDrawing()
         {
-            return this.legacyDrawingField != null;
+            return this.legacyDrawing != null;
         }
         public void UnsetLegacyDrawing()
         {
-            this.legacyDrawingField = null;
+            this.legacyDrawing = null;
         }
         public bool IsSetPageSetup()
         {
-            return this.pageSetupField != null;
+            return this.pageSetup != null;
         }
         public bool IsSetTableParts()
         {
-            return this.tablePartsField != null;
+            return this.tableParts != null;
         }
         public bool IsSetSheetCalcPr()
         {
-            return this.sheetCalcPrField != null;
+            return this.sheetCalcPr != null;
         }
         public CT_SheetProtection AddNewSheetProtection()
         {
-            this.sheetProtectionField = new CT_SheetProtection();
-            return this.sheetProtectionField;
+            this.sheetProtection = new CT_SheetProtection();
+            return this.sheetProtection;
         }
         public CT_TableParts AddNewTableParts()
         {
-            this.tablePartsField = new CT_TableParts();
-            return this.tablePartsField;
+            this.tableParts = new CT_TableParts();
+            return this.tableParts;
         }
         public CT_PageMargins AddNewPageMargins()
         {
-            this.pageMarginsField = new CT_PageMargins();
-            return this.pageMarginsField;
+            this.pageMargins = new CT_PageMargins();
+            return this.pageMargins;
         }
         public CT_PageSetup AddNewPageSetup()
         {
-            this.pageSetupField = new CT_PageSetup();
-            return this.pageSetupField;
+            this.pageSetup = new CT_PageSetup();
+            return this.pageSetup;
         }
         public void SetColsArray(List<CT_Cols> a)
         {
-            this.colsField = a;
+            this.cols = a;
         }
         public int sizeOfColsArray()
         {
-            return (null == colsField) ? 0 : this.colsField.Count;
+            return (null == cols) ? 0 : this.cols.Count;
         }
         public void RemoveCols(int index)
         {
-            this.colsField.RemoveAt(index);
+            this.cols.RemoveAt(index);
         }
         public CT_Cols AddNewCols()
         {
-            if (null == colsField) { colsField = new List<CT_Cols>(); }
+            if (null == cols) { cols = new List<CT_Cols>(); }
             CT_Cols newCols = new CT_Cols();
-            this.colsField.Add(newCols);
+            this.cols.Add(newCols);
             return newCols;
         }
         public void SetColsArray(int index, CT_Cols newCols)
         {
-            if (null == colsField)
+            if (null == cols)
             {
-                colsField = new List<CT_Cols>();
+                cols = new List<CT_Cols>();
             }
             else
             {
-                colsField.Clear();
+                cols.Clear();
             }
-            this.colsField.Insert(index, newCols);
+            this.cols.Insert(index, newCols);
         }
         public CT_Cols GetColsArray(int index)
         {
-            if (null == colsField)
+            if (null == cols)
             {
-                colsField = new List<CT_Cols>();
-                colsField.Add(new CT_Cols());
+                cols = new List<CT_Cols>();
+                cols.Add(new CT_Cols());
             }
-            return this.colsField[index];
+            return this.cols[index];
         }
         public List<CT_Cols> GetColsList()
         {
-            return this.colsField;
+            return this.cols;
         }
         public bool IsSetPageMargins()
         {
-            return this.pageMarginsField != null;
+            return this.pageMargins != null;
         }
         public bool IsSetHyperLinks()
         {
-            return this.hyperlinksField != null;
+            return this.hyperlinks != null;
         }
         public bool IsSetSheetPr()
         {
-            return this.sheetPrField != null;
+            return this.sheetPr != null;
         }
         public int SizeOfConditionalFormattingArray()
         {
+            return this.conditionalFormattingField?.Count ?? 0;
             return (null == conditionalFormattingField) ? 0 : this.conditionalFormatting.Count;
         }
 
         public void UnsetSheetProtection()
         {
-            this.sheetProtectionField = null;
+            this.sheetProtection = null;
         }
 
         public CT_SheetFormatPr AddNewSheetFormatPr()
         {
-            this.sheetFormatPrField = new CT_SheetFormatPr();
-            return sheetFormatPrField;
+            this.sheetFormatPr = new CT_SheetFormatPr();
+            return sheetFormatPr;
         }
         public CT_SheetCalcPr AddNewSheetCalcPr()
         {
-            this.sheetCalcPrField = new CT_SheetCalcPr();
-            return sheetCalcPrField;
+            this.sheetCalcPr = new CT_SheetCalcPr();
+            return sheetCalcPr;
         }
         public CT_SheetPr AddNewSheetPr()
         {
-            this.sheetPrField = new CT_SheetPr();
-            return sheetPrField;
+            this.sheetPr = new CT_SheetPr();
+            return sheetPr;
         }
         public CT_SheetDimension AddNewDimension()
         {
-            this.dimensionField = new CT_SheetDimension();
-            return dimensionField;
+            this.dimension = new CT_SheetDimension();
+            return dimension;
         }
         public CT_SheetData AddNewSheetData()
         {
-            this.sheetDataField = new CT_SheetData();
-            return sheetDataField;
+            this.sheetData = new CT_SheetData();
+            return sheetData;
         }
-        [XmlElement("sheetPr")]//, Order=0)]
-        public CT_SheetPr sheetPr
-        {
-            get
-            {
-                return this.sheetPrField;
-            }
-            set
-            {
-                this.sheetPrField = value;
-            }
-        }
+        [XmlElement(nameof(sheetPr))]//, Order=0)]
+        public CT_SheetPr sheetPr { get; set; } = null;
 
         [XmlElement]
-        public CT_SheetDimension dimension
-        {
-            get
-            {
-                return this.dimensionField;
-            }
-            set
-            {
-                this.dimensionField = value;
-            }
-        }
+        public CT_SheetDimension dimension { get; set; } = null;
         [XmlElement]
-        public CT_SheetViews sheetViews
-        {
-            get
-            {
-                return this.sheetViewsField;
-            }
-            set
-            {
-                this.sheetViewsField = value;
-            }
-        }
+        public CT_SheetViews sheetViews { get; set; } = null;
         [XmlElement]
-        public CT_SheetFormatPr sheetFormatPr
-        {
-            get
-            {
-                return this.sheetFormatPrField;
-            }
-            set
-            {
-                this.sheetFormatPrField = value;
-            }
-        }
+        public CT_SheetFormatPr sheetFormatPr { get; set; } = null;
 
         //[XmlArray(Order = 4)]
         // [XmlArrayItem("cols", typeof(CT_Cols), IsNullable = false)]
-        [XmlElement("cols")]
-        public List<CT_Cols> cols
-        {
-            get
-            {
-                return this.colsField;
-            }
-            set
-            {
-                this.colsField = value;
-            }
-        }
+        [XmlElement(nameof(cols))]
+        public List<CT_Cols> cols { get; set; } = new List<CT_Cols>();
 
-        [XmlElement("sheetData", IsNullable = false)]
-        public CT_SheetData sheetData
-        {
-            get
-            {
-                return this.sheetDataField;
-            }
-            set
-            {
-                this.sheetDataField = value;
-            }
-        }
+        [XmlElement(nameof(sheetData), IsNullable = false)]
+        public CT_SheetData sheetData { get; set; } = new CT_SheetData();
         [XmlElement]
-        public CT_SheetCalcPr sheetCalcPr
-        {
-            get
-            {
-                return this.sheetCalcPrField;
-            }
-            set
-            {
-                this.sheetCalcPrField = value;
-            }
-        }
+        public CT_SheetCalcPr sheetCalcPr { get; set; } = null;
         [XmlElement]
-        public CT_SheetProtection sheetProtection
-        {
-            get
-            {
-                return this.sheetProtectionField;
-            }
-            set
-            {
-                this.sheetProtectionField = value;
-            }
-        }
+        public CT_SheetProtection sheetProtection { get; set; } = null;
 
         [XmlElement]
-        public CT_ProtectedRanges protectedRanges
-        {
-            get
-            {
-                return this.protectedRangesField;
-            }
-            set
-            {
-                this.protectedRangesField = value;
-            }
-        }
+        public CT_ProtectedRanges protectedRanges { get; set; } = null;
 
-        public CT_Scenarios scenarios
-        {
-            get
-            {
-                return this.scenariosField;
-            }
-            set
-            {
-                this.scenariosField = value;
-            }
-        }
+        public CT_Scenarios scenarios { get; set; } = null;
 
-        public CT_AutoFilter autoFilter
-        {
-            get
-            {
-                return this.autoFilterField;
-            }
-            set
-            {
-                this.autoFilterField = value;
-            }
-        }
+        public CT_AutoFilter autoFilter { get; set; } = null;
 
-        public CT_SortState sortState
-        {
-            get
-            {
-                return this.sortStateField;
-            }
-            set
-            {
-                this.sortStateField = value;
-            }
-        }
+        public CT_SortState sortState { get; set; } = null;
 
-        public CT_DataConsolidate dataConsolidate
-        {
-            get
-            {
-                return this.dataConsolidateField;
-            }
-            set
-            {
-                this.dataConsolidateField = value;
-            }
-        }
+        public CT_DataConsolidate dataConsolidate { get; set; } = null;
 
         [XmlElement]
-        public CT_CustomSheetViews customSheetViews
-        {
-            get
-            {
-                return this.customSheetViewsField;
-            }
-            set
-            {
-                this.customSheetViewsField = value;
-            }
-        }
+        public CT_CustomSheetViews customSheetViews { get; set; } = null;
         [XmlElement]
-        public CT_MergeCells mergeCells
-        {
-            get
-            {
-                return this.mergeCellsField;
-            }
-            set
-            {
-                this.mergeCellsField = value;
-            }
-        }
+        public CT_MergeCells mergeCells { get; set; } = null;
         [XmlElement]
-        public CT_PhoneticPr phoneticPr
-        {
-            get
-            {
-                return this.phoneticPrField;
-            }
-            set
-            {
-                this.phoneticPrField = value;
-            }
-        }
+        public CT_PhoneticPr phoneticPr { get; set; } = null;
         [XmlElement]
         public List<CT_ConditionalFormatting> conditionalFormatting
         {
@@ -725,264 +444,54 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
         [XmlElement]
-        public CT_DataValidations dataValidations
-        {
-            get
-            {
-                return this.dataValidationsField;
-            }
-            set
-            {
-                this.dataValidationsField = value;
-            }
-        }
+        public CT_DataValidations dataValidations { get; set; } = null;
 
         //[XmlArray(Order = 18)]
         [XmlElement]
-        public CT_Hyperlinks hyperlinks
-        {
-            get
-            {
-                return this.hyperlinksField;
-            }
-            set
-            {
-                this.hyperlinksField = value;
-            }
-        }
+        public CT_Hyperlinks hyperlinks { get; set; } = null;
         [XmlElement]
-        public CT_PrintOptions printOptions
-        {
-            get
-            {
-                return this.printOptionsField;
-            }
-            set
-            {
-                this.printOptionsField = value;
-            }
-        }
+        public CT_PrintOptions printOptions { get; set; } = null;
 
         [XmlElement]
-        public CT_PageMargins pageMargins
-        {
-            get
-            {
-                return this.pageMarginsField;
-            }
-            set
-            {
-                this.pageMarginsField = value;
-            }
-        }
+        public CT_PageMargins pageMargins { get; set; } = null;
         [XmlElement]
-        public CT_PageSetup pageSetup
-        {
-            get
-            {
-                return this.pageSetupField;
-            }
-            set
-            {
-                this.pageSetupField = value;
-            }
-        }
+        public CT_PageSetup pageSetup { get; set; } = null;
         [XmlElement]
-        public CT_HeaderFooter headerFooter
-        {
-            get
-            {
-                return this.headerFooterField;
-            }
-            set
-            {
-                this.headerFooterField = value;
-            }
-        }
+        public CT_HeaderFooter headerFooter { get; set; } = null;
         [XmlElement]
-        public CT_PageBreak rowBreaks
-        {
-            get
-            {
-                return this.rowBreaksField;
-            }
-            set
-            {
-                this.rowBreaksField = value;
-            }
-        }
+        public CT_PageBreak rowBreaks { get; set; } = null;
         [XmlElement]
-        public CT_PageBreak colBreaks
-        {
-            get
-            {
-                return this.colBreaksField;
-            }
-            set
-            {
-                this.colBreaksField = value;
-            }
-        }
+        public CT_PageBreak colBreaks { get; set; } = null;
 
         [XmlElement]
-        public CT_CustomProperties customProperties
-        {
-            get
-            {
-                return this.customPropertiesField;
-            }
-            set
-            {
-                this.customPropertiesField = value;
-            }
-        }
+        public CT_CustomProperties customProperties { get; set; } = null;
 
         [XmlElement]
-        public CT_CellWatches cellWatches
-        {
-            get
-            {
-                return this.cellWatchesField;
-            }
-            set
-            {
-                this.cellWatchesField = value;
-            }
-        }
+        public CT_CellWatches cellWatches { get; set; } = null;
         [XmlElement]
-        public CT_IgnoredErrors ignoredErrors
-        {
-            get
-            {
-                return this.ignoredErrorsField;
-            }
-            set
-            {
-                this.ignoredErrorsField = value;
-            }
-        }
+        public CT_IgnoredErrors ignoredErrors { get; set; } = null;
         [XmlElement]
-        public CT_CellSmartTags smartTags
-        {
-            get
-            {
-                return this.smartTagsField;
-            }
-            set
-            {
-                this.smartTagsField = value;
-            }
-        }
+        public CT_CellSmartTags smartTags { get; set; } = null;
         [XmlElement]
-        public CT_Drawing drawing
-        {
-            get
-            {
-                return this.drawingField;
-            }
-            set
-            {
-                this.drawingField = value;
-            }
-        }
+        public CT_Drawing drawing { get; set; } = null;
         [XmlElement]
-        public CT_LegacyDrawing legacyDrawing
-        {
-            get
-            {
-                return this.legacyDrawingField;
-            }
-            set
-            {
-                this.legacyDrawingField = value;
-            }
-        }
+        public CT_LegacyDrawing legacyDrawing { get; set; } = null;
         [XmlElement]
-        public CT_LegacyDrawing legacyDrawingHF
-        {
-            get
-            {
-                return this.legacyDrawingHFField;
-            }
-            set
-            {
-                this.legacyDrawingHFField = value;
-            }
-        }
+        public CT_LegacyDrawing legacyDrawingHF { get; set; } = null;
         [XmlElement]
-        public CT_SheetBackgroundPicture picture
-        {
-            get
-            {
-                return this.pictureField;
-            }
-            set
-            {
-                this.pictureField = value;
-            }
-        }
+        public CT_SheetBackgroundPicture picture { get; set; } = null;
 
         [XmlElement]
-        public CT_OleObjects oleObjects
-        {
-            get
-            {
-                return this.oleObjectsField;
-            }
-            set
-            {
-                this.oleObjectsField = value;
-            }
-        }
+        public CT_OleObjects oleObjects { get; set; } = null;
 
         [XmlElement]
-        public CT_Controls controls
-        {
-            get
-            {
-                return this.controlsField;
-            }
-            set
-            {
-                this.controlsField = value;
-            }
-        }
+        public CT_Controls controls { get; set; } = null;
         [XmlElement]
-        public CT_WebPublishItems webPublishItems
-        {
-            get
-            {
-                return this.webPublishItemsField;
-            }
-            set
-            {
-                this.webPublishItemsField = value;
-            }
-        }
+        public CT_WebPublishItems webPublishItems { get; set; } = null;
         [XmlElement]
-        public CT_TableParts tableParts
-        {
-            get
-            {
-                return this.tablePartsField;
-            }
-            set
-            {
-                this.tablePartsField = value;
-            }
-        }
+        public CT_TableParts tableParts { get; set; } = null;
         [XmlElement]
-        public CT_ExtensionList extLst
-        {
-            get
-            {
-                return this.extLstField;
-            }
-            set
-            {
-                this.extLstField = value;
-            }
-        }
+        public CT_ExtensionList extLst { get; set; } = null;
 
         public void UnsetPageSetup()
         {


### PR DESCRIPTION
I tried to fix it in a modern way, but how is it?

1. string.Format

```cs
// before
string.Format("{0}", anyVariable) 
// after
$"{anyVariable}
```
2. AutoProperty

```cs
// before
private CT_CellFormula fField = null;
public CT_CellFormula 
{
    get
    {
        return this.fField;
    }
    set
    {
        this.fField = value;
    }
}

// after
public CT_CellFormula f { get; set; } = null;
```

3. use nameof
changed attribute name setting

```cs
// before
XmlHelper.WriteAttribute(sw, "r", this.r);

// after
XmlHelper.WriteAttribute(sw, nameof(r), this.r);
```

4. optimized null check
```cs
// before
if (this.authors != null)
    this.authors.Write(sw, "authors");

// after
this.authors?.Write(sw, nameof(authors));
```