### PR TITLE
added SpacingBetween (XWPFParagraph)

### DIFF
--- a/OpenXmlFormats/Wordprocessing/Document.cs
+++ b/OpenXmlFormats/Wordprocessing/Document.cs
@@ -108,7 +108,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
 
         public CT_Document()
         {
-            //this.bodyField = new CT_Body();
+            this.bodyField = new CT_Body();
         }
 
         [XmlElement(Order = 0)]
@@ -146,7 +146,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
 
         public CT_Body()
         {
-            //this.sectPrField = new CT_SectPr();
+            this.sectPrField = new CT_SectPr();
             this.itemsElementNameField = new List<DocumentBodyItemChoiceType>();
             this.itemsField = new ArrayList();
         }

--- a/OpenXmlFormats/Wordprocessing/Paragraph.cs
+++ b/OpenXmlFormats/Wordprocessing/Paragraph.cs
@@ -3497,7 +3497,10 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
         {
             return !(this.lineRuleField == ST_LineSpacingRule.nil);
         }
-
+        public bool IsSetBetweenLines()
+        {
+            return !string.IsNullOrEmpty(this.lineField);
+        }
         public bool IsSetAfter()
         {
             return !(this.afterField == 0);

--- a/ooxml/POIXMLDocumentPart.cs
+++ b/ooxml/POIXMLDocumentPart.cs
@@ -424,10 +424,6 @@ using System.Xml;
         {
             return CreateRelationship(descriptor, factory, idx, false);
         }
-        public POIXMLDocumentPart CreateRelation(POIXMLRelation descriptor, POIXMLFactory factory, int idx,bool noRelation)
-        {
-            return CreateRelationship(descriptor, factory, idx, noRelation);
-        }
 
         /**
          * Create a new child POIXMLDocumentPart

--- a/ooxml/XWPF/Usermodel/XWPFDocument.cs
+++ b/ooxml/XWPF/Usermodel/XWPFDocument.cs
@@ -291,8 +291,21 @@ namespace NPOI.XWPF.UserModel
             {
                 return ctDocument;
             }
+            set
+            {
+                ctDocument = value;
+            }
         }
-
+        /**
+         * Sets columns on document base object
+         */
+        public void setColumnCount(int num)
+        {
+            if(ctDocument != null)
+            {
+                ctDocument.body.sectPr.cols.num = num.ToString();
+            }
+        }
         internal IdentifierManager DrawingIdManager
         {
             get

--- a/ooxml/XWPF/Usermodel/XWPFDocument.cs
+++ b/ooxml/XWPF/Usermodel/XWPFDocument.cs
@@ -62,8 +62,6 @@ namespace NPOI.XWPF.UserModel
         protected XWPFNumbering numbering;
         protected XWPFStyles styles;
         protected XWPFFootnotes footnotes;
-        protected int columnCountField;
-        protected ST_TextDirection textDirectionField;
 
         /** Handles the joy of different headers/footers for different pages */
         private XWPFHeaderFooterPolicy headerFooterPolicy;
@@ -305,7 +303,7 @@ namespace NPOI.XWPF.UserModel
         {
             get
             {
-                return this.columnCountField;
+                return int.Parse(ctDocument.body.sectPr.cols.num);
             }
             set
             {
@@ -313,7 +311,6 @@ namespace NPOI.XWPF.UserModel
                 {
                     ctDocument.body.sectPr.cols.num = value.ToString();
                 }
-                this.columnCountField = value;
 
             }
             
@@ -325,7 +322,7 @@ namespace NPOI.XWPF.UserModel
         {
             get
             {
-                return this.textDirectionField;
+                return ctDocument.body.sectPr.textDirection.val;
             }
             set
             {
@@ -333,7 +330,6 @@ namespace NPOI.XWPF.UserModel
                 {
                     ctDocument.body.sectPr.textDirection.val = value;
                 }
-                this.textDirectionField = value;
             }
             
         }

--- a/ooxml/XWPF/Usermodel/XWPFDocument.cs
+++ b/ooxml/XWPF/Usermodel/XWPFDocument.cs
@@ -63,6 +63,7 @@ namespace NPOI.XWPF.UserModel
         protected XWPFStyles styles;
         protected XWPFFootnotes footnotes;
         protected int columnCountField;
+        protected ST_TextDirection textDirectionField;
 
         /** Handles the joy of different headers/footers for different pages */
         private XWPFHeaderFooterPolicy headerFooterPolicy;
@@ -312,18 +313,29 @@ namespace NPOI.XWPF.UserModel
                 {
                     ctDocument.body.sectPr.cols.num = value.ToString();
                 }
+                this.columnCountField = value;
+
             }
             
         }
         /**
          * Sets Text Direction of Document
          */
-         public void setTextDirection(ST_TextDirection direction)
+         public ST_TextDirection TextDirection
         {
-            if (ctDocument != null)
+            get
             {
-                ctDocument.body.sectPr.textDirection.val = direction;
+                return this.textDirectionField;
             }
+            set
+            {
+                if (ctDocument != null)
+                {
+                    ctDocument.body.sectPr.textDirection.val = value;
+                }
+                this.textDirectionField = value;
+            }
+            
         }
         internal IdentifierManager DrawingIdManager
         {

--- a/ooxml/XWPF/Usermodel/XWPFParagraph.cs
+++ b/ooxml/XWPF/Usermodel/XWPFParagraph.cs
@@ -963,6 +963,8 @@ namespace NPOI.XWPF.UserModel
         /// line attribute. If this attribute is omitted, then it shall be assumed to
         /// be of a value auto if a line attribute value is present.
         /// </summary>
+        
+        
         public LineSpacingRule SpacingLineRule
         {
             get
@@ -978,6 +980,27 @@ namespace NPOI.XWPF.UserModel
             }
         }
 
+        /// <summary>
+        /// Return the spacing between lines of a paragraph. The units of the return value depends on the
+        /// LineSpacingRule. If AUTO, the return value is in lines, otherwise the return
+        /// value is in points.
+        /// </summary>
+        public double SpacingBetween
+        {
+            get
+            {
+                CT_Spacing spacing = GetCTSpacing(false);
+                return (spacing != null && spacing.IsSetBetweenLines()) ? double.Parse(spacing.line) : -1;
+            }
+
+            set
+            {
+                CT_Spacing spacing = GetCTSpacing(true);
+                //BigInteger bi = new BigInteger("" + spaces);
+                spacing.line = value.ToString();
+            }
+
+        }
 
         /**
          * Specifies the indentation which shall be placed between the left text

--- a/ooxml/XWPF/Usermodel/XWPFParagraph.cs
+++ b/ooxml/XWPF/Usermodel/XWPFParagraph.cs
@@ -958,13 +958,14 @@ namespace NPOI.XWPF.UserModel
             }
         }
 
-        /// <summary>
-        ///Specifies how the spacing between lines is calculated as stored in the
-        /// line attribute. If this attribute is omitted, then it shall be assumed to
-        /// be of a value auto if a line attribute value is present.
-        /// </summary>
-        
-        
+        /**
+         * Specifies how the spacing between lines is calculated as stored in the
+         * line attribute. If this attribute is omitted, then it shall be assumed to
+         * be of a value auto if a line attribute value is present.
+         *
+         * @param rule
+         * @see LineSpacingRule
+         */
         public LineSpacingRule SpacingLineRule
         {
             get
@@ -979,12 +980,13 @@ namespace NPOI.XWPF.UserModel
                 spacing.lineRule = EnumConverter.ValueOf<ST_LineSpacingRule, LineSpacingRule>(value);
             }
         }
-
-        /// <summary>
-        /// Return the spacing between lines of a paragraph. The units of the return value depends on the
-        /// LineSpacingRule. If AUTO, the return value is in lines, otherwise the return
-        /// value is in points.
-        /// </summary>
+        /**
+        * Return the spacing between lines of a paragraph. The units of the return value depends on the
+        * {@see LineSpacingRule}. If AUTO, the return value is in lines, otherwise the return
+        * value is in points
+        *
+        * @return a double specifying points or lines.
+        */
         public double SpacingBetween
         {
             get
@@ -995,10 +997,23 @@ namespace NPOI.XWPF.UserModel
 
             set
             {
-                CT_Spacing spacing = GetCTSpacing(true);
-                //BigInteger bi = new BigInteger("" + spaces);
-                spacing.line = value.ToString();
+                setSpacingBetween(value, LineSpacingRule.AUTO);
             }
+
+        }
+        public void setSpacingBetween(double spacing, LineSpacingRule rule)
+        {
+            CT_Spacing ctSp = GetCTSpacing(true);
+            switch (rule)
+            {
+                case LineSpacingRule.AUTO:
+                    ctSp.line = Math.Round(spacing * 240.0).ToString();
+                    break;
+                default:
+                    ctSp.line = Math.Round(spacing * 20.0).ToString();
+                    break;
+            }
+            ctSp.lineRule = EnumConverter.ValueOf<ST_LineSpacingRule, LineSpacingRule>(rule);
 
         }
 


### PR DESCRIPTION
## LineSpacing value can be set.

Example:
```c#
foreach (XWPFParagraph par in newDoc.Paragraphs)
{
     // Double Space
     par.SpacingBetween = 480;
}
```

Similar to Apache Poi
[XWPF.setSpacingBetween(double spacing)](https://poi.apache.org/apidocs/dev/org/apache/poi/xwpf/usermodel/XWPFParagraph.html#setSpacingBetween-double-)