### PR TITLE
Fix XSSFExcelExtractor to emit empty cells

### DIFF
--- a/ooxml/XSSF/Extractor/XSSFExcelExtractor.cs
+++ b/ooxml/XSSF/Extractor/XSSFExcelExtractor.cs
@@ -197,7 +197,7 @@ namespace NPOI.XSSF.Extractor
                         IRow row = (IRow)rawR;
                         IEnumerator ri =row.GetEnumerator();
                         bool firsttime=true;
-                        while (ri.MoveNext())
+                        for (int j = 0; j < row.LastCellNum; j++)
                         {
                             if (!firsttime)
                             {
@@ -207,7 +207,9 @@ namespace NPOI.XSSF.Extractor
                             {
                                 firsttime = false;
                             }
-                            ICell cell = (ICell)ri.Current;
+                            ICell cell = (ICell)row.GetCell(j);
+                            if (cell == null)
+                                continue;
 
                             // Is it a formula one?
                             if (cell.CellType == CellType.Formula)

--- a/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
+++ b/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
@@ -212,6 +212,37 @@ namespace NPOI.XSSF.Extractor
             Assert.IsTrue(text.Contains("A5-A$2"), "Unable to find expected word in text\n" + text);
             extractor.Close();
         }
+
+        [Test]
+        public void TestEmptyCells()
+        {
+            XSSFExcelExtractor extractor = GetExtractor("SimpleNormal.xlsx");
+
+            String text = extractor.Text;
+            Assert.IsTrue(text.Length > 0);
+            
+            // This sheet demonstrates the preservation of empty cells, as
+            // signified by sequential \t characters.
+            Assert.AreEqual(
+                // Sheet 1
+                "Sheet1\n" + 
+                "test\t\t1\n" + 
+                "test 2\t\t2\n" + 
+                "\t\t3\n" + 
+                "\t\t4\n" + 
+                "\t\t5\n" + 
+                "\t\t6\n" + 
+                // Sheet 2
+                "Sheet Number 2\n" + 
+                "This is sheet 2\n" + 
+                "Stuff\n" + 
+                "1\t2\t3\t4\t5\t6\n" + 
+                "1/1/90\n" + 
+                "10\t\t3\n", 
+                text);
+
+            extractor.Close();
+        }
     }
 }
 


### PR DESCRIPTION
The default IRow enumerator will skip empty cells. This makes it so that the output from the Text property has cells that don't line up with their corresponding headers.

This fix calls GetCell instead, which will return null in cases where the cell was empty. The tab delimiters work as expected now.