### PR TITLE
Fix some test cases

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -3397,7 +3397,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 this.selectUnlockedCellsField = value;
             }
         }
-
+        // default value of CT_SheetProtection BOOLEAN attribute, see OfficeOpenXML-XMLSchema\sml-sheet.xsd
+        // | attribute           | default value |
+        // |---------------------|---------------|
+        // | sheet               |    false      |
+        // | objects             |    false      |
+        // | scenarios           |    false      |
+        // | formatCells         |    true       |
+        // | formatColumns       |    true       |
+        // | formatRows          |    true       |
+        // | insertColumns       |    true       |
+        // | insertHyperlinks    |    true       |
+        // | deleteColumns       |    true       |
+        // | deleteRows          |    true       |
+        // | selectLockedCells   |    false      |
+        // | sort                |    true       |
+        // | autoFilter          |    true       |
+        // | pivotTables         |    true       |
+        // | selectUnlockedCells |    false      |
         public static CT_SheetProtection Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
@@ -3407,18 +3424,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.sheet = XmlHelper.ReadBool(node.Attributes["sheet"]);
             ctObj.objects = XmlHelper.ReadBool(node.Attributes["objects"]);
             ctObj.scenarios = XmlHelper.ReadBool(node.Attributes["scenarios"]);
-            ctObj.formatCells = XmlHelper.ReadBool(node.Attributes["formatCells"]);
-            ctObj.formatColumns = XmlHelper.ReadBool(node.Attributes["formatColumns"]);
-            ctObj.formatRows = XmlHelper.ReadBool(node.Attributes["formatRows"]);
-            ctObj.insertColumns = XmlHelper.ReadBool(node.Attributes["insertColumns"]);
-            ctObj.insertRows = XmlHelper.ReadBool(node.Attributes["insertRows"]);
-            ctObj.insertHyperlinks = XmlHelper.ReadBool(node.Attributes["insertHyperlinks"]);
-            ctObj.deleteColumns = XmlHelper.ReadBool(node.Attributes["deleteColumns"]);
-            ctObj.deleteRows = XmlHelper.ReadBool(node.Attributes["deleteRows"]);
+            ctObj.formatCells = XmlHelper.ReadBool(node.Attributes["formatCells"], true);
+            ctObj.formatColumns = XmlHelper.ReadBool(node.Attributes["formatColumns"], true);
+            ctObj.formatRows = XmlHelper.ReadBool(node.Attributes["formatRows"], true);
+            ctObj.insertColumns = XmlHelper.ReadBool(node.Attributes["insertColumns"], true);
+            ctObj.insertRows = XmlHelper.ReadBool(node.Attributes["insertRows"], true);
+            ctObj.insertHyperlinks = XmlHelper.ReadBool(node.Attributes["insertHyperlinks"], true);
+            ctObj.deleteColumns = XmlHelper.ReadBool(node.Attributes["deleteColumns"], true);
+            ctObj.deleteRows = XmlHelper.ReadBool(node.Attributes["deleteRows"], true);
             ctObj.selectLockedCells = XmlHelper.ReadBool(node.Attributes["selectLockedCells"]);
-            ctObj.sort = XmlHelper.ReadBool(node.Attributes["sort"]);
-            ctObj.autoFilter = XmlHelper.ReadBool(node.Attributes["autoFilter"]);
-            ctObj.pivotTables = XmlHelper.ReadBool(node.Attributes["pivotTables"]);
+            ctObj.sort = XmlHelper.ReadBool(node.Attributes["sort"], true);
+            ctObj.autoFilter = XmlHelper.ReadBool(node.Attributes["autoFilter"], true);
+            ctObj.pivotTables = XmlHelper.ReadBool(node.Attributes["pivotTables"], true);
             ctObj.selectUnlockedCells = XmlHelper.ReadBool(node.Attributes["selectUnlockedCells"]);
             return ctObj;
         }

--- a/main/SS/Format/CellNumberPartHandler.cs
+++ b/main/SS/Format/CellNumberPartHandler.cs
@@ -170,15 +170,15 @@ namespace NPOI.SS.Format
                 Special s = specials[i];
                 if (IsDigitFmt(s))
                 {
-                    Special numStart = s;
+                    //Special numStart = s;
                     Special last = s;
-                    while (i > 0)
+                    while (i >= 0)
                     {
-                        i--;
                         s = specials[i];
-                        if (last.pos - s.pos > 1 || IsDigitFmt(s)) // it has to be continuous digits
+                        if (last.pos - s.pos > 1 || !IsDigitFmt(s)) // it has to be continuous digits
                             break;
                         last = s;
+                        i--;
                     }
                     return last;
                 }

--- a/main/Util/IOUtils.cs
+++ b/main/Util/IOUtils.cs
@@ -63,6 +63,31 @@ namespace NPOI.Util
 
             return header;
         }
+        public static byte[] PeekFirst8Bytes(Stream stream)
+        {
+            // We want to peek at the first 8 bytes
+            long mark =  stream.Position;
+
+            byte[] header = new byte[8];
+            int read = IOUtils.ReadFully(stream, header);
+
+            if (read < 1)
+                throw new EmptyFileException();
+
+            // Wind back those 8 bytes
+            if (stream is PushbackInputStream)
+            {
+                //PushbackInputStream pin = (PushbackInputStream)stream;
+                //pin.Unread(header, 0, read);
+                stream.Position -= read;
+            }
+            else
+            {
+                stream.Position = mark;
+            }
+
+            return header;
+        }
         /// <summary>
         /// Reads all the data from the input stream, and returns
         /// the bytes Read.

--- a/ooxml/POIXMLProperties.cs
+++ b/ooxml/POIXMLProperties.cs
@@ -663,7 +663,7 @@ namespace NPOI
                 PackagePart tPart = ThumbnailPart;
                 if (tPart == null) return null;
                 String name = tPart.PartName.Name;
-                return name.Substring(name.LastIndexOf('/'));
+                return name.Substring(name.LastIndexOf('/') + 1);
             }
         }
         /**

--- a/ooxml/SS/UserModel/WorkbookFactory.cs
+++ b/ooxml/SS/UserModel/WorkbookFactory.cs
@@ -130,7 +130,7 @@ namespace NPOI.SS.UserModel
             //}
             inputStream = new PushbackStream(inputStream);
             // Ensure that there is at least some data there
-            //byte[] header8 = IOUtils.PeekFirst8Bytes(inputStream);
+            byte[] header8 = IOUtils.PeekFirst8Bytes(inputStream);
 
             if (POIFSFileSystem.HasPOIFSHeader(inputStream))
             {

--- a/testcases/main/HSSF/UserModel/TestCloneSheet.cs
+++ b/testcases/main/HSSF/UserModel/TestCloneSheet.cs
@@ -19,20 +19,19 @@
 
 namespace TestCases.HSSF.UserModel
 {
-    using System;
-    using NPOI.HSSF.UserModel;
-    using NPOI.SS.Util;
-    using NUnit.Framework;
-    using NPOI.SS.UserModel;
     using NPOI.DDF;
     using NPOI.HSSF.Record;
+    using NPOI.HSSF.UserModel;
     using NPOI.Util;
+    using NUnit.Framework;
+    using TestCases.SS.UserModel;
+
     /**
-     * Test the ability to clone a sheet. 
-     *  If Adding new records that belong to a sheet (as opposed to a book)
-     *  Add that record to the sheet in the TestCloneSheetBasic method. 
-     * @author  avik
-     */
+* Test the ability to clone a sheet. 
+*  If Adding new records that belong to a sheet (as opposed to a book)
+*  Add that record to the sheet in the TestCloneSheetBasic method. 
+* @author  avik
+*/
     [TestFixture]
     public class TestCloneSheet : BaseTestCloneSheet
     {

--- a/testcases/main/SS/Formula/Eval/BaseTestCircularReferences.cs
+++ b/testcases/main/SS/Formula/Eval/BaseTestCircularReferences.cs
@@ -27,7 +27,6 @@ namespace TestCases.SS.Formula.Eval
      * Common superclass for testing cases of circular references
      * both for HSSF and XSSF
      */
-    [TestFixture]
     public abstract class BaseTestCircularReferences
     {
 

--- a/testcases/main/SS/Formula/Eval/Forked/TestForkedEvaluator.cs
+++ b/testcases/main/SS/Formula/Eval/Forked/TestForkedEvaluator.cs
@@ -17,14 +17,13 @@
 
 namespace TestCases.SS.Formula.Eval.Forked
 {
-    using System;
-    using NUnit.Framework;
     using NPOI.HSSF.UserModel;
     using NPOI.SS.Formula;
     using NPOI.SS.Formula.Eval;
-    using NPOI.SS.UserModel;
-    using TestCases.SS.Formula.Eval.Forked;
     using NPOI.SS.Formula.Eval.Forked;
+    using NPOI.SS.UserModel;
+    using NUnit.Framework;
+    using System;
 
     /**
      * @author Josh Micich

--- a/testcases/main/SS/UserModel/BaseTestBorderStyle.cs
+++ b/testcases/main/SS/UserModel/BaseTestBorderStyle.cs
@@ -29,8 +29,7 @@ namespace TestCases.SS.UserModel
     /**
      * Tests of {@link BorderStyle}
      */
-    [TestFixture, Explicit]
-    public class BaseTestBorderStyle
+    public abstract class BaseTestBorderStyle
     {
 
         private ITestDataProvider _testDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestBugzillaIssues.cs
+++ b/testcases/main/SS/UserModel/BaseTestBugzillaIssues.cs
@@ -17,35 +17,28 @@
 
 namespace TestCases.SS.UserModel
 {
-    using System;
-
-    using NUnit.Framework;
-
-    using NPOI.HSSF.Util;
-    using NPOI.SS;
-    using NPOI.SS.Util;
-    using System.Text;
-    using NPOI.SS.UserModel;
-    using System.Collections.Generic;
     using NPOI.HSSF.UserModel;
+    using NPOI.SS;
+    using NPOI.SS.UserModel;
+    using NPOI.SS.Util;
+    using NPOI.Util;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
     using System.Drawing;
     using System.IO;
-    using NPOI.Util;
+    using System.Text;
 
     /**
      * A base class for bugzilla issues that can be described in terms of common ss interfaces.
      *
      * @author Yegor Kozlov
      */
-    [TestFixture]
-    public class BaseTestBugzillaIssues
+    public abstract class BaseTestBugzillaIssues
     {
 
         private ITestDataProvider _testDataProvider;
-        public BaseTestBugzillaIssues()
-        {
-            _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
-        }
+
         protected BaseTestBugzillaIssues(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestCell.cs
+++ b/testcases/main/SS/UserModel/BaseTestCell.cs
@@ -17,31 +17,23 @@
 
 namespace TestCases.SS.UserModel
 {
-    using System;
-
-    using NUnit.Framework;
-    using TestCases.SS;
-    using NPOI.SS.UserModel;
-    using NPOI.SS.Util;
-    using NPOI.HSSF.Util;
     using NPOI.HSSF.UserModel;
-    using System.Text;
+    using NPOI.HSSF.Util;
     using NPOI.SS;
-    using System.Collections.Generic;
+    using NPOI.SS.UserModel;
+    using NUnit.Framework;
+    using System;
+    using System.Text;
+    using TestCases.SS;
 
     /**
      * Common superclass for testing implementatiosn of
      *  {@link NPOI.SS.usermodel.Cell}
      */
-    [TestFixture, Explicit]
-    public class BaseTestCell
+    public abstract class BaseTestCell
     {
 
         protected ITestDataProvider _testDataProvider;
-
-        public BaseTestCell()
-            : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
-        { }
 
         /**
          * @param testDataProvider an object that provides test data in HSSF / XSSF specific way

--- a/testcases/main/SS/UserModel/BaseTestCloneSheet.cs
+++ b/testcases/main/SS/UserModel/BaseTestCloneSheet.cs
@@ -15,8 +15,9 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.SS.UserModel
+namespace TestCases.SS.UserModel
 {
+    using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NUnit.Framework;
     using System;
@@ -26,7 +27,6 @@ namespace NPOI.SS.UserModel
      * Common superclass for testing implementations of
      * Workbook.CloneSheet()
      */
-    [TestFixture]
     public abstract class BaseTestCloneSheet
     {
 

--- a/testcases/main/SS/UserModel/BaseTestFormulaEvaluator.cs
+++ b/testcases/main/SS/UserModel/BaseTestFormulaEvaluator.cs
@@ -17,25 +17,22 @@
 
 namespace TestCases.SS.UserModel
 {
-    using System;
-
-    using NUnit.Framework;
-
-    using NPOI.SS;
     using NPOI.SS.UserModel;
+    using NUnit.Framework;
+    using System;
 
     /**
      * Common superclass for Testing implementatiosn of{@link FormulaEvaluator}
      *
      * @author Yegor Kozlov
      */
-    public class BaseTestFormulaEvaluator
+    public abstract class BaseTestFormulaEvaluator
     {
 
         protected ITestDataProvider _testDataProvider;
-        public BaseTestFormulaEvaluator()
-            : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
-        { }
+        //public BaseTestFormulaEvaluator()
+        //    : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
+        //{ }
         /**
          * @param TestDataProvider an object that provides Test data in  /  specific way
          */

--- a/testcases/main/SS/UserModel/BaseTestNamedRange.cs
+++ b/testcases/main/SS/UserModel/BaseTestNamedRange.cs
@@ -17,8 +17,6 @@
 
 namespace TestCases.SS.UserModel
 {
-
-
     using System;
     using NUnit.Framework;
     using NPOI.SS.UserModel;
@@ -31,14 +29,13 @@ namespace TestCases.SS.UserModel
      *
      * @author Yegor Kozlov
      */
-    [TestFixture]
-    public class BaseTestNamedRange
+    public abstract class BaseTestNamedRange
     {
 
         private ITestDataProvider _testDataProvider;
-        public BaseTestNamedRange()
-            : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
-        { }
+        //public BaseTestNamedRange()
+        //    : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
+        //{ }
         protected BaseTestNamedRange(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestSheet.cs
+++ b/testcases/main/SS/UserModel/BaseTestSheet.cs
@@ -18,29 +18,23 @@
 
 namespace TestCases.SS.UserModel
 {
-    using System;
-    using System.Linq;
-    using NUnit.Framework;
     using NPOI.SS;
-    using NPOI.SS.Util;
     using NPOI.SS.UserModel;
+    using NPOI.SS.Util;
+    using NUnit.Framework;
+    using System;
     using System.Collections;
-    using NPOI.HSSF.UserModel;
     using System.Collections.Generic;
-    using NPOI.Util;
+    using System.Linq;
 
     /**
      * Common superclass for Testing {@link NPOI.xssf.UserModel.XSSFCell}  and
      * {@link NPOI.HSSF.UserModel.HSSFCell}
      */
-    [TestFixture]
-    public class BaseTestSheet
+    public abstract class BaseTestSheet
     {
         private static int ROW_COUNT = 40000;
         private ITestDataProvider _testDataProvider;
-        public BaseTestSheet()
-            : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
-        { }
         protected BaseTestSheet(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestSheetAutosizeColumn.cs
+++ b/testcases/main/SS/UserModel/BaseTestSheetAutosizeColumn.cs
@@ -17,15 +17,10 @@
 
 namespace TestCases.SS.UserModel
 {
-    using System;
-
-    using NUnit.Framework;
-    using NPOI.SS;
-    using NPOI.SS.Util;
     using NPOI.SS.UserModel;
-    using System.Collections;
-    using System.IO;
-    using NPOI.HSSF.UserModel;
+    using NPOI.SS.Util;
+    using NUnit.Framework;
+    using System;
 
 
 
@@ -34,15 +29,14 @@ namespace TestCases.SS.UserModel
      *
      * @author Yegor Kozlov
      */
-    [TestFixture]
-    public class BaseTestSheetAutosizeColumn
+    public abstract class BaseTestSheetAutosizeColumn
     {
 
         private ITestDataProvider _testDataProvider;
-        public BaseTestSheetAutosizeColumn()
-        {
-            _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
-        }
+        //public BaseTestSheetAutosizeColumn()
+        //{
+        //    _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
+        //}
         protected BaseTestSheetAutosizeColumn(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestSheetShiftRows.cs
+++ b/testcases/main/SS/UserModel/BaseTestSheetShiftRows.cs
@@ -17,16 +17,13 @@
 
 namespace TestCases.SS.UserModel
 {
-    using System;
-
-    using NUnit.Framework;
-
-    using NPOI.SS;
-    using NPOI.SS.Util;
-    using TestCases.SS;
-    using NPOI.SS.UserModel;
     using NPOI.HSSF.UserModel;
+    using NPOI.SS.UserModel;
+    using NPOI.SS.Util;
+    using NUnit.Framework;
+    using System;
     using System.Collections.Generic;
+    using TestCases.SS;
 
     /**
      * Tests row Shifting capabilities.
@@ -34,14 +31,14 @@ namespace TestCases.SS.UserModel
      * @author Shawn Laubach (slaubach at apache dot com)
      * @author Toshiaki Kamoshida (kamoshida.Toshiaki at future dot co dot jp)
      */
-    public class BaseTestSheetShiftRows
+    public abstract class BaseTestSheetShiftRows
     {
 
         private ITestDataProvider _testDataProvider;
-        public BaseTestSheetShiftRows()
-        {
-            _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
-        }
+        //public BaseTestSheetShiftRows()
+        //{
+        //    _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
+        //}
         protected BaseTestSheetShiftRows(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestSheetUpdateArrayFormulas.cs
+++ b/testcases/main/SS/UserModel/BaseTestSheetUpdateArrayFormulas.cs
@@ -32,14 +32,13 @@ namespace TestCases.SS.UserModel
      * @author Yegor Kozlov
      * @author Josh Micich
      */
-    [TestFixture]
-    public class BaseTestSheetUpdateArrayFormulas
+    public abstract class BaseTestSheetUpdateArrayFormulas
     {
         protected ITestDataProvider _testDataProvider;
-        public BaseTestSheetUpdateArrayFormulas()
-        {
-            _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
-        }
+        //public BaseTestSheetUpdateArrayFormulas()
+        //{
+        //    _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
+        //}
         protected BaseTestSheetUpdateArrayFormulas(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/UserModel/BaseTestWorkbook.cs
+++ b/testcases/main/SS/UserModel/BaseTestWorkbook.cs
@@ -17,31 +17,26 @@
 
 namespace TestCases.SS.UserModel
 {
+    using NPOI.SS;
+    using NPOI.SS.UserModel;
+    using NPOI.SS.Util;
+    using NPOI.Util;
+    using NUnit.Framework;
     using System;
     using System.Collections;
-    using NUnit.Framework;
-    using NPOI.SS.Util;
-    using TestCases.SS;
-    using NPOI.SS.UserModel;
     using System.Text;
-    using System.IO;
-    using NPOI.Util;
-    using NPOI.SS;
     using TestCases.HSSF;
+    using TestCases.SS;
     using TestCases.Util;
 
     /**
      * @author Yegor Kozlov
      */
-    [TestFixture]
     public abstract class BaseTestWorkbook
     {
 
         protected ITestDataProvider _testDataProvider;
-        public BaseTestWorkbook()
-        {
-            _testDataProvider = TestCases.HSSF.HSSFITestDataProvider.Instance;
-        }
+
         protected BaseTestWorkbook(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;

--- a/testcases/main/SS/Util/BaseTestCellUtil.cs
+++ b/testcases/main/SS/Util/BaseTestCellUtil.cs
@@ -17,24 +17,22 @@
 
 namespace TestCases.SS.Util
 {
-    using System;
-    using System.Collections.Generic;
-    using NPOI.HSSF.UserModel;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NUnit.Framework;
-    using TestCases.HSSF;
+    using System;
+    using System.Collections.Generic;
     using TestCases.SS;
 
-    
-    public class BaseTestCellUtil
+
+    public abstract class BaseTestCellUtil
     {
         protected ITestDataProvider _testDataProvider;
-        public BaseTestCellUtil()
-            : this(HSSFITestDataProvider.Instance)
-        {
+        //public BaseTestCellUtil()
+        //    : this(HSSFITestDataProvider.Instance)
+        //{
 
-        }
+        //}
         protected BaseTestCellUtil(ITestDataProvider testDataProvider)
         {
             _testDataProvider = testDataProvider;

--- a/testcases/ooxml/POIFS/Crypt/TestAgileEncryptionParameters.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestAgileEncryptionParameters.cs
@@ -14,15 +14,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.IO;
+    using NPOI.POIFS.Crypt;
     using NPOI.POIFS.FileSystem;
     using NPOI.Util;
     using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
     using TestCases;
 
     [TestFixture]

--- a/testcases/ooxml/POIFS/Crypt/TestCertificateEncryption.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestCertificateEncryption.cs
@@ -14,10 +14,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
     using System;
     using System.IO;
+    using NPOI.POIFS.Crypt;
     using NPOI.POIFS.Crypt.Agile;
     using NPOI.POIFS.FileSystem;
     using NPOI.Util;

--- a/testcases/ooxml/POIFS/Crypt/TestDecryptor.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestDecryptor.cs
@@ -14,15 +14,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
-    using System;
-    using System.IO;
     using ICSharpCode.SharpZipLib.Zip;
+    using NPOI.POIFS.Crypt;
     using NPOI.POIFS.FileSystem;
     using NPOI.Util;
     using NPOI.XSSF;
     using NUnit.Framework;
+    using System.IO;
     using TestCases;
 
     /**

--- a/testcases/ooxml/POIFS/Crypt/TestEncryptionInfo.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestEncryptionInfo.cs
@@ -14,9 +14,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
-    using System;
+    using NPOI.POIFS.Crypt;
     using NPOI.POIFS.FileSystem;
     using NUnit.Framework;
     using TestCases;

--- a/testcases/ooxml/POIFS/Crypt/TestEncryptor.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestEncryptor.cs
@@ -14,12 +14,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using NPOI.OpenXml4Net.OPC;
+    using NPOI.POIFS.Crypt;
     using NPOI.POIFS.Crypt.Agile;
     using NPOI.POIFS.FileSystem;
     using NPOI.Util;

--- a/testcases/ooxml/POIFS/Crypt/TestSecureTempZip.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestSecureTempZip.cs
@@ -15,23 +15,20 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
-    using System;
-    using System.IO;
-    using System.Collections.Generic;
     using ICSharpCode.SharpZipLib.Zip;
-    using NPOI.OpenXml4Net.Exceptions;
     using NPOI.OpenXml4Net.OPC;
     using NPOI.OpenXml4Net.Util;
+    using NPOI.POIFS.Crypt;
     using NPOI.POIFS.FileSystem;
     using NPOI.Util;
     using NPOI.XSSF;
-    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
     using Org.BouncyCastle.Security;
-    using NPOI.POIFS.Crypt.Standard;
+    using System;
     using System.Collections;
+    using System.IO;
 
     [TestFixture]
     public class TestSecureTempZip

--- a/testcases/ooxml/POIFS/Crypt/TestSignatureInfo.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestSignatureInfo.cs
@@ -21,22 +21,16 @@
    http://code.google.com/p/eid-applet/source/browse/tRunk/README.txt  
    Copyright (C) 2008-2014 FedICT.
    ================================================================= */
-using NPOI.Util;
-using System;
 using System.IO;
 
-namespace NPOI.POIFS.Crypt
+namespace TestCases.POIFS.Crypt
 {
+    using NPOI.OpenXml4Net.OPC;
+    using NPOI.POIFS.Crypt.Dsig;
+    using NUnit.Framework;
     using System;
     using System.Collections.Generic;
     using System.Security.Cryptography.X509Certificates;
-    using NPOI.OpenXml4Net.OPC;
-    using NPOI.POIFS.Crypt.Dsig;
-    using NPOI.POIFS.Crypt.Dsig.Facets;
-    using NPOI.POIFS.Crypt.Dsig.Services;
-
-    using NPOI.XSSF.UserModel;
-    using NUnit.Framework;
     using TestCases;
 
     [TestFixture]

--- a/testcases/ooxml/SS/Converter/TestExcelToHtmlConverterSuite.cs
+++ b/testcases/ooxml/SS/Converter/TestExcelToHtmlConverterSuite.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using NPOI.HSSF.UserModel;
+using NPOI.SS.Converter;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using NPOI.HSSF.UserModel;
-using NUnit.Framework;
-using TestCases;
 
-namespace NPOI.SS.Converter
+namespace TestCases.SS.Converter
 {
     [TestFixture]
     public class TestExcelToHtmlConverterSuite

--- a/testcases/ooxml/SS/Format/TestCellFormatPart.cs
+++ b/testcases/ooxml/SS/Format/TestCellFormatPart.cs
@@ -14,16 +14,16 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.SS.Format
+namespace TestCases.SS.Format
 {
-    using System;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using NUnit.Framework;
+    using NPOI.SS.Format;
     using NPOI.SS.UserModel;
     using NPOI.XSSF;
-    using TestCases.SS.Format;
+    using NUnit.Framework;
+    using System;
     using System.Globalization;
+    using System.Text;
+    using System.Text.RegularExpressions;
 
 
 

--- a/testcases/ooxml/SS/Formula/Eval/TestXSSFCircularReferences.cs
+++ b/testcases/ooxml/SS/Formula/Eval/TestXSSFCircularReferences.cs
@@ -15,13 +15,11 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.SS.Formula.Eval
+namespace TestCases.SS.Formula.Eval
 {
-    using System;
 
     using NPOI.XSSF;
     using NUnit.Framework;
-    using TestCases.SS.Formula.Eval;
 
     /**
      * Tests XSSFFormulaEvaluator for its handling of cell formula circular references.

--- a/testcases/ooxml/SS/Formula/Functions/TestProper.cs
+++ b/testcases/ooxml/SS/Formula/Functions/TestProper.cs
@@ -15,12 +15,13 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.SS.Formula.Functions
+namespace TestCases.SS.Formula.Functions
 {
     using System;
     using System.Text;
     using NPOI.HSSF.UserModel;
     using NPOI.SS.Formula.Eval;
+    using NPOI.SS.Formula.Functions;
     using NPOI.SS.UserModel;
     using NPOI.Util;
     using NPOI.XSSF.UserModel;

--- a/testcases/ooxml/SS/Formula/TestStructuredReferences.cs
+++ b/testcases/ooxml/SS/Formula/TestStructuredReferences.cs
@@ -15,7 +15,7 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.SS.Formula
+namespace TestCases.SS.Formula
 {
     using System;
 

--- a/testcases/ooxml/SS/TestWorkbookFactory.cs
+++ b/testcases/ooxml/SS/TestWorkbookFactory.cs
@@ -15,20 +15,21 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.SS
+namespace TestCases.SS
 {
-    using System;
-    using NUnit.Framework;
+    using NPOI;
     using NPOI.HSSF.UserModel;
+    using NPOI.OpenXml4Net.Exceptions;
     using NPOI.OpenXml4Net.OPC;
     using NPOI.POIFS.FileSystem;
     using NPOI.SS.UserModel;
-    using NPOI.XSSF.UserModel;
-    using TestCases.HSSF;
-    using System.Configuration;
-    using System.IO;
-    using NPOI.OpenXml4Net.Exceptions;
     using NPOI.Util;
+    using NPOI.XSSF.UserModel;
+    using NUnit.Framework;
+    using System;
+    using System.IO;
+    using TestCases;
+    using TestCases.HSSF;
 
     [TestFixture]
     public class TestWorkbookFactory
@@ -39,7 +40,8 @@ namespace NPOI.SS
         private readonly String[] xlsx_prot = new String[] { "protected_passtika.xlsx", "tika" };
         private readonly String txt = "SampleSS.txt";
 
-        private readonly string testdataPath = ConfigurationManager.AppSettings["POI.testdata.path"] + "\\spreadsheet\\";
+        private readonly string testdataPath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+            TestContext.Parameters[POIDataSamples.TEST_PROPERTY] + "\\spreadsheet\\");
         private static POILogger LOGGER = POILogFactory.GetLogger(typeof(TestWorkbookFactory));
 
         /**

--- a/testcases/ooxml/SS/UserModel/BaseTestXRow.cs
+++ b/testcases/ooxml/SS/UserModel/BaseTestXRow.cs
@@ -27,7 +27,6 @@ namespace TestCases.SS.UserModel
      *  Any test that is applicable for {@link NPOI.HSSF.UserModel.HSSFRow} as well should go into
      *  the common base class {@link BaseTestRow}.
      */
-    [TestFixture]
     public abstract class BaseTestXRow : BaseTestRow
     {
         protected BaseTestXRow(ITestDataProvider testDataProvider)

--- a/testcases/ooxml/SS/UserModel/BaseTestXSheet.cs
+++ b/testcases/ooxml/SS/UserModel/BaseTestXSheet.cs
@@ -17,7 +17,6 @@
 
 namespace TestCases.SS.UserModel
 {
-    using NUnit.Framework;
     using TestCases.SS;
 
     /**
@@ -27,7 +26,6 @@ namespace TestCases.SS.UserModel
      *  Any test that is applicable for {@link NPOI.HSSF.UserModel.HSSFSheet} as well should go into
      *  the common base class {@link BaseTestSheet}.
      */
-    [TestFixture]
     public abstract class BaseTestXSheet : BaseTestSheet
     {
         protected BaseTestXSheet(ITestDataProvider testDataProvider)

--- a/testcases/ooxml/SS/UserModel/TestFormulaParser.cs
+++ b/testcases/ooxml/SS/UserModel/TestFormulaParser.cs
@@ -23,13 +23,8 @@ using NPOI.XSSF;
 using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace NPOI.SS.UserModel
+namespace TestCases.SS.UserModel
 {
     [TestFixture]
     public class TestFormulaParser

--- a/testcases/ooxml/SS/UserModel/TestXSSFBorderStyle.cs
+++ b/testcases/ooxml/SS/UserModel/TestXSSFBorderStyle.cs
@@ -15,7 +15,7 @@
    limitations under the License.
 ==================================================================== */
 
-namespace Testcases.SS.UserModel
+namespace TestCases.SS.UserModel
 {
     using NPOI.XSSF;
     using NUnit.Framework;

--- a/testcases/ooxml/SS/Util/TestSXSSFCellUtil.cs
+++ b/testcases/ooxml/SS/Util/TestSXSSFCellUtil.cs
@@ -17,9 +17,8 @@
 
 using NPOI.XSSF;
 using NUnit.Framework;
-using TestCases.SS.Util;
 
-namespace Testcases.OOXML.SS.Util
+namespace TestCases.SS.Util
 {
     [TestFixture]
     public class TestSXSSFCellUtil : BaseTestCellUtil

--- a/testcases/ooxml/SS/Util/TestXSSFCellUtil.cs
+++ b/testcases/ooxml/SS/Util/TestXSSFCellUtil.cs
@@ -19,7 +19,7 @@ using NPOI.XSSF;
 using NUnit.Framework;
 using TestCases.SS.Util;
 
-namespace Testcases.OOXML.SS.Util
+namespace TestCases.SS.Util
 {
     [TestFixture]
     public class TestXSSFCellUtil : BaseTestCellUtil

--- a/testcases/ooxml/TestDetectAsOOXML.cs
+++ b/testcases/ooxml/TestDetectAsOOXML.cs
@@ -16,14 +16,15 @@
    limitations under the License.
 ==================================================================== */
 
-using System.IO;
-using NUnit.Framework;
+using NPOI;
 using NPOI.OpenXml4Net.OPC;
-using NPOI.Util;
-using TestCases.HSSF;
 using NPOI.POIFS.FileSystem;
+using NPOI.Util;
+using NUnit.Framework;
+using System.IO;
+using TestCases.HSSF;
 
-namespace NPOI.OOXML
+namespace TestCases.OOXML
 {
 
     /**

--- a/testcases/ooxml/TestPOIXMLDocument.cs
+++ b/testcases/ooxml/TestPOIXMLDocument.cs
@@ -15,19 +15,19 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.OOXML
+namespace TestCases.OOXML
 {
-    using System;
-    using NPOI.Util;
-    using System.Collections.Generic;
-    using NUnit.Framework;
-    using System.IO;
-    using NPOI.OpenXml4Net.OPC;
     using NPOI;
+    using NPOI.OpenXml4Net.Exceptions;
+    using NPOI.OpenXml4Net.OPC;
+    using NPOI.Util;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text.RegularExpressions;
     using TestCases;
     using TestCases.Util;
-    using System.Text.RegularExpressions;
-    using NPOI.OpenXml4Net.Exceptions;
 
     /**
      * Test recursive read and write of OPC namespaces

--- a/testcases/ooxml/Util/TestIdentifierManager.cs
+++ b/testcases/ooxml/Util/TestIdentifierManager.cs
@@ -14,9 +14,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
+using NPOI.Util;
 using NUnit.Framework;
 using System;
-namespace NPOI.Util
+namespace TestCases.Util
 {
     [TestFixture]
     public class TestIdentifierManager

--- a/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
+++ b/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
@@ -20,7 +20,11 @@ using NUnit.Framework;
 using NPOI.HSSF.Extractor;
 using TestCases.HSSF;
 using System.Text.RegularExpressions;
-namespace NPOI.XSSF.Extractor
+using NPOI.XSSF.Extractor;
+using NPOI.XSSF;
+using NPOI;
+
+namespace TestCases.XSSF.Extractor
 {
 
     /**

--- a/testcases/ooxml/XSSF/Extractor/TestXSSFExportToXML.cs
+++ b/testcases/ooxml/XSSF/Extractor/TestXSSFExportToXML.cs
@@ -15,15 +15,19 @@
    limitations under the License.
 ==================================================================== */
 
-using NPOI.XSSF.UserModel;
+using NPOI;
+using NPOI.XSSF;
+using NPOI.XSSF.Extractor;
 using NPOI.XSSF.Model;
-using System.IO;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using System;
-using System.Xml;
-using System.Text.RegularExpressions;
+using System.IO;
 using System.Text;
-namespace NPOI.XSSF.Extractor
+using System.Text.RegularExpressions;
+using System.Xml;
+
+namespace TestCases.XSSF.Extractor
 {
 
     /**

--- a/testcases/ooxml/XSSF/IO/TestLoadSaveXSSF.cs
+++ b/testcases/ooxml/XSSF/IO/TestLoadSaveXSSF.cs
@@ -15,13 +15,11 @@
    limitations under the License.
 ==================================================================== */
 
-using TestCases;
+using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
 using NUnit.Framework;
-using NPOI.SS.UserModel;
-using System.Collections.Generic;
 using System.Collections;
-namespace NPOI.XSSF.IO
+namespace TestCases.XSSF.IO
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/Model/TestCalculationChain.cs
+++ b/testcases/ooxml/XSSF/Model/TestCalculationChain.cs
@@ -19,7 +19,10 @@ using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using NPOI.SS.UserModel;
 using NPOI.OpenXmlFormats.Spreadsheet;
-namespace NPOI.XSSF.Model
+using NPOI.XSSF;
+using NPOI.XSSF.Model;
+
+namespace TestCases.XSSF.Model
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/Model/TestCommentsTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestCommentsTable.cs
@@ -19,9 +19,11 @@ using System;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
+using NPOI.XSSF;
+using NPOI.XSSF.Model;
 using NPOI.XSSF.UserModel;
 using NUnit.Framework;
-namespace NPOI.XSSF.Model
+namespace TestCases.XSSF.Model
 {
 
 

--- a/testcases/ooxml/XSSF/Model/TestExternalLinksTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestExternalLinksTable.cs
@@ -15,11 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.Model
+namespace TestCases.XSSF.Model
 {
-    using System;
 
     using NPOI.SS.UserModel;
+    using NPOI.XSSF;
+    using NPOI.XSSF.Model;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 

--- a/testcases/ooxml/XSSF/Model/TestMapInfo.cs
+++ b/testcases/ooxml/XSSF/Model/TestMapInfo.cs
@@ -14,11 +14,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-using NPOI.XSSF.UserModel;
+using NPOI;
 using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.XSSF;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
-using System.Xml;
-namespace NPOI.XSSF.Model
+namespace TestCases.XSSF.Model
 {
 
     /**

--- a/testcases/ooxml/XSSF/Model/TestSharedStringsTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestSharedStringsTable.cs
@@ -23,7 +23,11 @@ using System;
 using NPOI.SS.UserModel;
 using TestCases;
 using System.IO;
-namespace NPOI.XSSF.Model
+using NPOI.XSSF.Model;
+using NPOI.XSSF;
+using NPOI;
+
+namespace TestCases.XSSF.Model
 {
 
     /**

--- a/testcases/ooxml/XSSF/Model/TestStylesTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestStylesTable.cs
@@ -20,8 +20,10 @@ using NUnit.Framework;
 using NPOI.XSSF.UserModel;
 using System.Collections.Generic;
 using NPOI.SS.UserModel;
+using NPOI.XSSF.Model;
+using NPOI.XSSF;
 
-namespace NPOI.XSSF.Model
+namespace TestCases.XSSF.Model
 {
     [TestFixture]
     public class TestStylesTable

--- a/testcases/ooxml/XSSF/Model/TestThemesTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestThemesTable.cs
@@ -15,7 +15,7 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.Model
+namespace TestCases.XSSF.Model
 {
     using System;
     using System.IO;
@@ -27,6 +27,7 @@ namespace NPOI.XSSF.Model
     using NPOI.SS.Util;
     using NPOI.Util;
     using NPOI.OpenXmlFormats.Spreadsheet;
+    using NPOI.XSSF.Model;
 
     [TestFixture]
     public class TestThemesTable

--- a/testcases/ooxml/XSSF/Streaming/GZIPSheetDataWriterTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/GZIPSheetDataWriterTests.cs
@@ -14,18 +14,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-using System.IO;
-using System.Linq;
-using System.Text;
 using ICSharpCode.SharpZipLib.GZip;
-using NPOI.XSSF.Model;
 using NPOI.XSSF.Streaming;
 using NUnit.Framework;
+using System.IO;
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     [TestFixture]
-    class GZIPSheetDataWriterTests
+    public class GZIPSheetDataWriterTests
     {
         private GZIPSheetDataWriter _objectToTest;
 

--- a/testcases/ooxml/XSSF/Streaming/SXSSFCellTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SXSSFCellTests.cs
@@ -18,7 +18,7 @@ using NPOI.SS.UserModel;
 using NPOI.XSSF.Streaming;
 using NUnit.Framework;
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     [TestFixture]
     class SXSSFCellTests

--- a/testcases/ooxml/XSSF/Streaming/SXSSFRowTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SXSSFRowTests.cs
@@ -19,7 +19,7 @@ using NPOI.SS.UserModel;
 using NPOI.XSSF.Streaming;
 using NUnit.Framework;
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     [TestFixture]
     class SXSSFRowTests

--- a/testcases/ooxml/XSSF/Streaming/SXSSFWorkbookTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SXSSFWorkbookTests.cs
@@ -24,7 +24,7 @@ using NPOI.XSSF.Streaming;
 using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     [TestFixture]
     class SXSSFWorkbookTests

--- a/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
@@ -14,18 +14,16 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-using System.IO;
-using System.Linq;
-using System.Text;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.Streaming;
 using NSubstitute;
 using NUnit.Framework;
+using System.IO;
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     [TestFixture]
-    class SheetDataWriterTests
+    public class SheetDataWriterTests
     {
         private SheetDataWriter _objectToTest;
         private SXSSFRow _row;

--- a/testcases/ooxml/XSSF/Streaming/TestAutoSizeColumnTracker.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestAutoSizeColumnTracker.cs
@@ -14,12 +14,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     using System;
     using System.Collections.Generic;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
+    using NPOI.XSSF.Streaming;
     using NUnit.Framework;
 
 

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFBugs.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFBugs.cs
@@ -3,14 +3,9 @@ using NPOI.SS.Util;
 using NPOI.XSSF;
 using NPOI.XSSF.Streaming;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TestCases.SS.UserModel;
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     public class TestSXSSFBugs : BaseTestBugzillaIssues
     {

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFCell.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFCell.cs
@@ -17,14 +17,14 @@
  * ====================================================================
  */
 
-namespace NPOI.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
-    using System;
     using NPOI.OpenXmlFormats.Spreadsheet;
     using NPOI.SS.UserModel;
     using NPOI.XSSF;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
+    using System;
     using TestCases.SS.UserModel;
 
     /**

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFFormulaEvaluation.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFFormulaEvaluation.cs
@@ -17,11 +17,11 @@
  * ====================================================================
  */
 
-namespace NPOI.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
-    using System;
-
     using NPOI.SS.UserModel;
+    using NPOI.XSSF;
+    using NPOI.XSSF.Streaming;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFRow.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFRow.cs
@@ -17,7 +17,7 @@
  * ====================================================================
  */
 
-namespace Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     using NPOI.XSSF;
     using NUnit.Framework;

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFSheet.cs
@@ -17,17 +17,14 @@
  * ====================================================================
  */
 
-namespace NPOI.OOXML.Testcases.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
-    using System;
-
-
-    using NPOI.SS;
     using NPOI.SS.UserModel;
     using NPOI.XSSF;
     using NPOI.XSSF.Streaming;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
+    using System;
     using TestCases.SS.UserModel;
 
     [TestFixture]
@@ -37,7 +34,7 @@ namespace NPOI.OOXML.Testcases.XSSF.Streaming
         public TestSXSSFSheet()
             : base(SXSSFITestDataProvider.instance)
         {
-            ;
+            
         }
 
 

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFSheetAutoSizeColumn.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFSheetAutoSizeColumn.cs
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
     using System;
     using System.Collections.Generic;

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFWorkbook.cs
@@ -17,22 +17,20 @@
  * ====================================================================
  */
 
-using NUnit.Framework;
-using System;
 
-namespace NPOI.XSSF.Streaming
+namespace TestCases.XSSF.Streaming
 {
-    using System;
-    using System.IO;
     using NPOI.OpenXml4Net.OPC;
-    using NPOI.SS;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NPOI.Util;
     using NPOI.XSSF;
     using NPOI.XSSF.Model;
+    using NPOI.XSSF.Streaming;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
+    using System;
+    using System.IO;
     using TestCases;
     using TestCases.SS.UserModel;
     using TestCases.Util;

--- a/testcases/ooxml/XSSF/TestSheetProtection.cs
+++ b/testcases/ooxml/XSSF/TestSheetProtection.cs
@@ -16,12 +16,9 @@
 ==================================================================== */
 namespace TestCases
 {
-    using System;
-
-    using NUnit.Framework;
-
-    using NPOI.XSSF.UserModel;
     using NPOI.XSSF;
+    using NPOI.XSSF.UserModel;
+    using NUnit.Framework;
 
     [TestFixture]
     public class TestSheetProtection

--- a/testcases/ooxml/XSSF/TestXSSFCloneSheet.cs
+++ b/testcases/ooxml/XSSF/TestXSSFCloneSheet.cs
@@ -15,13 +15,14 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF
+namespace TestCases.XSSF
 {
     using System;
     using NPOI.SS.UserModel;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
     using TestCases.HSSF;
+    using TestCases.SS.UserModel;
 
     [TestFixture]
     public class TestXSSFCloneSheet : BaseTestCloneSheet

--- a/testcases/ooxml/XSSF/UserModel/BaseTestXSSFPivotTable.cs
+++ b/testcases/ooxml/XSSF/UserModel/BaseTestXSSFPivotTable.cs
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using System.Collections.Generic;
@@ -22,10 +22,11 @@ namespace NPOI.XSSF.UserModel
     using NPOI.OpenXmlFormats.Spreadsheet;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
+    using NPOI.XSSF;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
 
-    [TestFixture]
     public abstract class BaseTestXSSFPivotTable
     {
         private static XSSFITestDataProvider _testDataProvider = XSSFITestDataProvider.instance;

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFCategoryAxis.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFCategoryAxis.cs
@@ -15,14 +15,13 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel.Charts
+namespace TestCases.XSSF.UserModel.Charts
 {
-    using System;
-
-    using NUnit.Framework;
 
     using NPOI.SS.UserModel.Charts;
     using NPOI.XSSF.UserModel;
+    using NPOI.XSSF.UserModel.Charts;
+    using NUnit.Framework;
 
     [TestFixture]
     public class TestXSSFCategoryAxis

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFChartAxis.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFChartAxis.cs
@@ -19,7 +19,9 @@ using System;
 using NUnit.Framework;
 using NPOI.SS.UserModel;
 using NPOI.SS.UserModel.Charts;
-namespace NPOI.XSSF.UserModel.Charts
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel.Charts
 {
     [TestFixture]
     public class TestXSSFChartAxis

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFChartLegend.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFChartLegend.cs
@@ -15,11 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-using System;
 using NUnit.Framework;
 using NPOI.SS.UserModel;
 using NPOI.SS.UserModel.Charts;
-namespace NPOI.XSSF.UserModel.Charts
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel.Charts
 {
     [TestFixture]
     public class TestXSSFChartLegend

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFChartTitle.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFChartTitle.cs
@@ -15,7 +15,7 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel.Charts
+namespace TestCases.XSSF.UserModel.Charts
 {
     using System;
     using System.Collections.Generic;

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFLineChartData.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFLineChartData.cs
@@ -1,4 +1,4 @@
-﻿namespace NPOI.XSSF.UserModel.Charts
+﻿namespace TestCases.XSSF.UserModel.Charts
 {
     using System;
 

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFManualLayout.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFManualLayout.cs
@@ -15,11 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-using System;
 using NUnit.Framework;
 using NPOI.SS.UserModel;
 using NPOI.SS.UserModel.Charts;
-namespace NPOI.XSSF.UserModel.Charts
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel.Charts
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFScatterChartData.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFScatterChartData.cs
@@ -20,7 +20,9 @@ using NPOI.SS.UserModel;
 using System;
 using NUnit.Framework;
 using NPOI.SS.UserModel.Charts;
-namespace NPOI.XSSF.UserModel.Charts
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel.Charts
 {
     /**
      * Tests for XSSFScatterChartData.

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFValueAxis.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFValueAxis.cs
@@ -15,12 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-using NPOI.SS.Util;
 using NPOI.SS.UserModel;
-using System;
-using NUnit.Framework;
 using NPOI.SS.UserModel.Charts;
-namespace NPOI.XSSF.UserModel.Charts
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+
+namespace TestCases.XSSF.UserModel.Charts
 {
     [TestFixture]
     public class TestXSSFValueAxis

--- a/testcases/ooxml/XSSF/UserModel/Extensions/TestXSSFBorder.cs
+++ b/testcases/ooxml/XSSF/UserModel/Extensions/TestXSSFBorder.cs
@@ -18,7 +18,9 @@
 using NPOI.SS.UserModel;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NUnit.Framework;
-namespace NPOI.XSSF.UserModel.Extensions
+using NPOI.XSSF.UserModel.Extensions;
+
+namespace TestCases.XSSF.UserModel.Extensions
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/Extensions/TestXSSFCellFill.cs
+++ b/testcases/ooxml/XSSF/UserModel/Extensions/TestXSSFCellFill.cs
@@ -17,7 +17,11 @@
 
 using NUnit.Framework;
 using NPOI.OpenXmlFormats.Spreadsheet;
-namespace NPOI.XSSF.UserModel.Extensions
+using NPOI.XSSF.UserModel.Extensions;
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel.Extensions
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/Helpers/TestColumnHelper.cs
+++ b/testcases/ooxml/XSSF/UserModel/Helpers/TestColumnHelper.cs
@@ -18,7 +18,10 @@
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NUnit.Framework;
 using NPOI.XSSF.Model;
-namespace NPOI.XSSF.UserModel.Helpers
+using NPOI.XSSF.UserModel.Helpers;
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel.Helpers
 {
     /**
      * Tests for {@link ColumnHelper}

--- a/testcases/ooxml/XSSF/UserModel/Helpers/TestHeaderFooterHelper.cs
+++ b/testcases/ooxml/XSSF/UserModel/Helpers/TestHeaderFooterHelper.cs
@@ -16,8 +16,9 @@
 ==================================================================== */
 
 using System;
+using NPOI.XSSF.UserModel.Helpers;
 using NUnit.Framework;
-namespace NPOI.XSSF.UserModel.Helpers
+namespace TestCases.XSSF.UserModel.Helpers
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestFormulaEvaluatorOnXSSF.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestFormulaEvaluatorOnXSSF.cs
@@ -24,7 +24,10 @@ using System.IO;
 using TestCases.HSSF;
 using NPOI.Util;
 using NPOI.SS.Util;
-namespace NPOI.XSSF.UserModel{
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
+{
 
 
     /**
@@ -250,7 +253,7 @@ namespace NPOI.XSSF.UserModel{
                             break;
                         default:
                             throw new RuntimeException("unexpected result");
-                        
+
                     }
                 }
                 rowIndex += SS.NUMBER_OF_ROWS_PER_FUNCTION;

--- a/testcases/ooxml/XSSF/UserModel/TestMissingWorkbookOnXSSF.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestMissingWorkbookOnXSSF.cs
@@ -15,16 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-    using System;
-
-    using NPOI.HSSF;
-    using NPOI.SS.Formula;
     using NPOI.XSSF;
-    using TestCases.SS.Formula;
     using NUnit.Framework;
     using TestCases.HSSF;
+    using TestCases.SS.Formula;
 
     /**
      * XSSF Specific version of the Missing Workbooks test

--- a/testcases/ooxml/XSSF/UserModel/TestMultiSheetFormulaEvaluatorOnXSSF.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestMultiSheetFormulaEvaluatorOnXSSF.cs
@@ -15,13 +15,14 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using System.IO;
     using NPOI.OpenXml4Net.OPC;
     using NPOI.SS.UserModel;
     using NPOI.Util;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
     using TestCases.HSSF;
     using TestCases.SS.Formula.Eval;

--- a/testcases/ooxml/XSSF/UserModel/TestSheetHiding.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestSheetHiding.cs
@@ -17,7 +17,9 @@
 
 using TestCases.SS.UserModel;
 using NUnit.Framework;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestUnfixedBugs.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestUnfixedBugs.cs
@@ -1,19 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using NUnit.Framework;
-using TestCases.HSSF;
-using NPOI.SS.UserModel;
-using NPOI.Util;
-using System.IO;
-using NPOI.OpenXmlFormats.Spreadsheet;
-using NPOI.HSSF.UserModel;
-using System.Globalization;
-using NPOI.XSSF.Streaming;
-using NPOI.SS.Util;
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
 
-namespace NPOI.XSSF.UserModel
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+using NPOI.Util;
+using NPOI.XSSF;
+using NPOI.XSSF.Streaming;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using TestCases.HSSF;
+
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestUnfixedBugs

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFBugs.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFBugs.cs
@@ -16,13 +16,9 @@
 ==================================================================== */
 
 using TestCases.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
+    using NPOI;
     using NPOI.HSSF.UserModel;
     using NPOI.OpenXml4Net.OPC;
     using NPOI.OpenXmlFormats.Spreadsheet;
@@ -36,9 +32,15 @@ namespace NPOI.XSSF.UserModel
     using NPOI.XSSF;
     using NPOI.XSSF.Model;
     using NPOI.XSSF.Streaming;
+    using NPOI.XSSF.UserModel;
     using NPOI.XSSF.UserModel.Extensions;
     using NUnit.Framework;
     using NUnit.Framework.Constraints;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
     using TestCases;
     using TestCases.HSSF;
     using static NPOI.POIXMLDocumentPart;

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFCell.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFCell.cs
@@ -26,8 +26,10 @@ using NPOI.SS;
 using TestCases.HSSF;
 using System.Text;
 using System.Collections.Generic;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     /**
@@ -204,7 +206,7 @@ namespace NPOI.XSSF.UserModel
             Assert.IsFalse(cell6.IsMergedCell);
             Assert.IsFalse(cell8.IsMergedCell);
 
-            sheet.AddMergedRegion(new SS.Util.CellRangeAddress(5, 6, 5, 6));   //region with 4 cells
+            sheet.AddMergedRegion(new CellRangeAddress(5, 6, 5, 6));   //region with 4 cells
 
             Assert.IsTrue(cell5.IsMergedCell);
             Assert.IsTrue(cell6.IsMergedCell);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFCellStyle.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFCellStyle.cs
@@ -23,7 +23,10 @@ using NPOI.SS.UserModel;
 using NPOI.HSSF.UserModel;
 using System.Drawing;
 using NPOI.HSSF.Util;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFChart.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFChart.cs
@@ -19,8 +19,10 @@ using NUnit.Framework;
 using NPOI.SS.UserModel;
 using System.Collections.Generic;
 using NPOI.SS.UserModel.Charts;
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFChart

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFChartSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFChartSheet.cs
@@ -16,11 +16,12 @@
 ==================================================================== */
 
 using NPOI.OpenXmlFormats.Spreadsheet;
-using NPOI.SS.UserModel;
 using NPOI.SS.Util;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFChartSheet

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFColGrouping.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFColGrouping.cs
@@ -16,8 +16,10 @@
 ==================================================================== */
 
 using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFColor.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFColor.cs
@@ -15,9 +15,10 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-
+    using NPOI.XSSF;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFComment.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFComment.cs
@@ -22,11 +22,13 @@ using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.OpenXmlFormats.Vml;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
+using NPOI.XSSF;
 using NPOI.XSSF.Model;
 using NPOI.XSSF.Streaming;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using TestCases.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     /**
      * @author Yegor Kozlov

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFConditionalFormatting.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFConditionalFormatting.cs
@@ -1,4 +1,6 @@
 using NPOI.SS.UserModel;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using System;
 /*
@@ -20,7 +22,7 @@ using System;
 * ====================================================================
 */
 using TestCases.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     /**
      * @author Yegor Kozlov

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDataFormat.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDataFormat.cs
@@ -18,7 +18,10 @@
 using TestCases.SS.UserModel;
 using NUnit.Framework;
 using NPOI.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
@@ -21,7 +21,10 @@ using NUnit.Framework;
 using NPOI.SS.Util;
 using System;
 using System.Text;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFDataValidation : BaseTestDataValidation

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidationConstraint.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidationConstraint.cs
@@ -14,10 +14,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using NPOI.SS.UserModel;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDrawing.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDrawing.cs
@@ -25,8 +25,11 @@ using System.Drawing;
 using NPOI.OpenXmlFormats.Dml.Spreadsheet;
 using System.Text;
 using static NPOI.POIXMLDocumentPart;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+using NPOI;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     /**
      * @author Yegor Kozlov
@@ -97,7 +100,7 @@ namespace NPOI.XSSF.UserModel
 
             XSSFConnector c1 = drawing.CreateConnector(new XSSFClientAnchor(0, 0, 0, 0, 0, 0, 2, 2));
             c1.LineWidth = 2.5;
-            c1.LineStyle = SS.UserModel.LineStyle.DashDotSys;
+            c1.LineStyle = LineStyle.DashDotSys;
 
             XSSFShapeGroup c2 = drawing.CreateGroup(new XSSFClientAnchor(0, 0, 0, 0, 0, 0, 5, 5));
             Assert.IsNotNull(c2);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFExternalFunctions.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFExternalFunctions.cs
@@ -17,7 +17,9 @@
 
 using TestCases.SS.Formula;
 using NUnit.Framework;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFFont.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFFont.cs
@@ -15,16 +15,18 @@
    limitations under the License.
 ==================================================================== */
 
-using TestCases.SS.UserModel;
-using NPOI.SS.UserModel;
+using NPOI;
 using NPOI.OpenXmlFormats.Spreadsheet;
-using NUnit.Framework;
-using System;
-using NPOI.Util;
-using System.Text;
+using NPOI.SS.UserModel;
 using NPOI.SS.Util;
+using NPOI.Util;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using System.Text;
+using TestCases.SS.UserModel;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFFont : BaseTestFont

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFForkedEvaluator.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFForkedEvaluator.cs
@@ -20,7 +20,7 @@ using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using TestCases.SS.Formula.Eval.Forked;
 
-namespace Testcases.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFForkedEvaluator : TestForkedEvaluator

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFFormulaEvaluation.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFFormulaEvaluation.cs
@@ -22,7 +22,10 @@ using NPOI.SS.Util;
 using System;
 using System.Collections.Generic;
 using TestCases.HSSF;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFFormulaParser.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFFormulaParser.cs
@@ -24,8 +24,10 @@ using TestCases.HSSF;
 using NPOI.HSSF.UserModel;
 using NPOI.Util;
 using NPOI.SS.Util;
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFFormulaParser

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFHeaderFooter.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFHeaderFooter.cs
@@ -18,7 +18,9 @@
 using System;
 using NUnit.Framework;
 using NPOI.OpenXmlFormats.Spreadsheet;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
 {
     /**
      * Tests for {@link XSSFHeaderFooter}

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFHyperlink.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFHyperlink.cs
@@ -22,8 +22,10 @@ using NPOI.SS.UserModel;
 using NPOI.OpenXml4Net.OPC;
 using NPOI.HSSF.UserModel;
 using NPOI.SS.Util;
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFHyperlink : BaseTestHyperlink

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFName.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFName.cs
@@ -19,7 +19,10 @@ using TestCases.SS.UserModel;
 using NUnit.Framework;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFPicture.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFPicture.cs
@@ -23,7 +23,10 @@ using NPOI.Util;
 using System.Text;
 using NPOI.OpenXmlFormats.Dml.Spreadsheet;
 using System.Collections;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFPictureData.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFPictureData.cs
@@ -22,7 +22,10 @@ using NPOI.Util;
 using NPOI.SS.UserModel;
 using System.Collections;
 using System.Text;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel
 {
     /**
      * @author Yegor Kozlov

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFPivotTableName.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFPivotTableName.cs
@@ -15,12 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-    using System;
 
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFPivotTableRef.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFPivotTableRef.cs
@@ -15,13 +15,13 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-    using System;
 
     using NPOI.SS;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
 

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFPrintSetup.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFPrintSetup.cs
@@ -18,7 +18,10 @@
 using NUnit.Framework;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF;
+
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFRichTextString.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFRichTextString.cs
@@ -15,13 +15,14 @@
    limitations under the License.
 ==================================================================== */
 
-using NUnit.Framework;
 using NPOI.OpenXmlFormats.Spreadsheet;
-using System.Collections.Generic;
-using System;
 using NPOI.SS.UserModel;
+using NPOI.XSSF;
 using NPOI.XSSF.Model;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using System;
+namespace TestCases.XSSF.UserModel
 {
     /**
      * Tests functionality of the XSSFRichTextRun object

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFRow.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFRow.cs
@@ -15,12 +15,13 @@
    limitations under the License.
 ==================================================================== */
 
-using TestCases.SS.UserModel;
-using NPOI.SS;
-using NUnit.Framework;
 using NPOI.SS.UserModel;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using TestCases.SS.UserModel;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -15,26 +15,25 @@
    limitations under the License.
 ==================================================================== */
 
-using NPOI.XSSF.UserModel;
-using NUnit.Framework;
-using NPOI.XSSF.UserModel.Helpers;
+using NPOI;
 using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.POIFS.Crypt;
+using NPOI.SS;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
-using NPOI.XSSF.Model;
-using System.Collections.Generic;
-using System;
 using NPOI.XSSF;
-using NPOI.Util;
-using NPOI.HSSF.Record;
-using TestCases.SS.UserModel;
-using TestCases.HSSF;
-using NPOI.SS;
-using NPOI.POIFS.Crypt;
-using System.Globalization;
+using NPOI.XSSF.Model;
 using NPOI.XSSF.Streaming;
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF.UserModel.Helpers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using TestCases.HSSF;
+using TestCases.SS.UserModel;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     [TestFixture]
     public class TestXSSFSheet : BaseTestXSheet

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetAutosizeColumn.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetAutosizeColumn.cs
@@ -15,9 +15,10 @@
    limitations under the License.
 ==================================================================== */
 
+using NPOI.XSSF;
 using NUnit.Framework;
 using TestCases.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetMergeRegions.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetMergeRegions.cs
@@ -14,14 +14,14 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
     using NPOI.SS.Util;
     using NPOI.XSSF;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
+    using System.Collections.Generic;
+    using System.Diagnostics;
 
     [TestFixture]
     public class TestXSSFSheetMergeRegions

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetRowGrouping.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetRowGrouping.cs
@@ -15,11 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using NPOI.SS.UserModel;
     using NPOI.XSSF;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetShiftRows.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetShiftRows.cs
@@ -15,15 +15,16 @@
    limitations under the License.
 ==================================================================== */
 
-using System;
-using System.Collections.Generic;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
-using TestCases;
+using System;
+using System.Collections.Generic;
 using TestCases.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetUpdateArrayFormulas.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetUpdateArrayFormulas.cs
@@ -21,7 +21,10 @@ using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
 using TestCases.SS.UserModel;
-namespace NPOI.XSSF.UserModel
+using NPOI.XSSF;
+using NPOI.XSSF.UserModel;
+
+namespace TestCases.XSSF.UserModel
 {
     /**
      * Test array formulas in XSSF

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSimpleShape.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSimpleShape.cs
@@ -14,13 +14,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using NPOI.SS.UserModel;
     using NUnit.Framework;
     using System.Drawing;
-
+    using NPOI.XSSF.UserModel;
 
     [TestFixture]
     public class TestXSSFSimpleShape

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFTable.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFTable.cs
@@ -15,7 +15,7 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using System.Collections.Generic;
@@ -23,6 +23,7 @@ namespace NPOI.XSSF.UserModel
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NPOI.XSSF;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
 
 

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFTextParagraph.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFTextParagraph.cs
@@ -14,12 +14,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
-    using System;
+    using NPOI.XSSF.UserModel;
     using NUnit.Framework;
-    using System.Drawing;
     using System.Collections.Generic;
+    using System.Drawing;
 
     [TestFixture]
     public class TestXSSFTextParagraph

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFTextRun.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFTextRun.cs
@@ -14,12 +14,14 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
     using System;
     using NUnit.Framework;
     using System.Collections.Generic;
     using System.Drawing;
+    using NPOI.XSSF.UserModel;
+
     [TestFixture]
     public class TestXSSFTextRun
     {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFVMLDrawing.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFVMLDrawing.cs
@@ -14,17 +14,16 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-using NUnit.Framework;
-using System.Collections.Generic;
 using NPOI.OpenXmlFormats.Vml;
 using NPOI.OpenXmlFormats.Vml.Office;
-using System.IO;
-using TestCases;
-using System.Collections;
 using NPOI.OpenXmlFormats.Vml.Spreadsheet;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
 using System;
+using System.Collections;
+using System.IO;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     /**

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -15,26 +15,27 @@
    limitations under the License.
 ==================================================================== */
 
-using NPOI.XSSF;
-using NPOI.OpenXmlFormats.Spreadsheet;
-using NUnit.Framework;
-using NPOI.SS.UserModel;
-using System.IO;
-using NPOI.Util;
+using NPOI;
 using NPOI.OpenXml4Net.OPC;
-using TestCases.HSSF;
-using NPOI.XSSF.Model;
 using NPOI.OpenXml4Net.OPC.Internal;
-using System.Collections.Generic;
-using System.Collections;
-using System;
-using TestCases.SS.UserModel;
-using System.Text;
-using NPOI.SS.Util;
-using TestCases;
+using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS;
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+using NPOI.Util;
+using NPOI.XSSF;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using TestCases.HSSF;
+using TestCases.SS.UserModel;
 
-namespace NPOI.XSSF.UserModel
+namespace TestCases.XSSF.UserModel
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/Util/TestCTColComparator.cs
+++ b/testcases/ooxml/XSSF/Util/TestCTColComparator.cs
@@ -17,9 +17,10 @@
 
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NUnit.Framework;
-using NPOI.Util;
 using System;
-namespace NPOI.XSSF.Util
+using NPOI.XSSF.Util;
+
+namespace TestCases.XSSF.Util
 {
 
     [TestFixture]

--- a/testcases/ooxml/XSSF/Util/TestEvilUnclosedBRFixingInputStream.cs
+++ b/testcases/ooxml/XSSF/Util/TestEvilUnclosedBRFixingInputStream.cs
@@ -19,7 +19,9 @@ using System.IO;
 using NUnit.Framework;
 using System.Text;
 using NPOI.Util;
-namespace NPOI.XSSF.Util
+using NPOI.XSSF.Util;
+
+namespace TestCases.XSSF.Util
 {
     [TestFixture]
     public class TestEvilUnclosedBRFixingInputStream

--- a/testcases/ooxml/XSSF/Util/TestNumericRanges.cs
+++ b/testcases/ooxml/XSSF/Util/TestNumericRanges.cs
@@ -15,8 +15,9 @@
    limitations under the License.
 ==================================================================== */
 
+using NPOI.XSSF.Util;
 using NUnit.Framework;
-namespace NPOI.XSSF.Util
+namespace TestCases.XSSF.Util
 {
 
     [TestFixture]

--- a/testcases/ooxml/XWPF/UserModel/TestXWPFTableRow.cs
+++ b/testcases/ooxml/XWPF/UserModel/TestXWPFTableRow.cs
@@ -15,12 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
-namespace NPOI.XWPF.UserModel
+namespace TestCases.XWPF.UserModel
 {
-    using System;
 
-    using NUnit.Framework;
     using NPOI.OpenXmlFormats.Wordprocessing;
+    using NPOI.XWPF.UserModel;
+    using NUnit.Framework;
 
     [TestFixture]
     public class TestXWPFTableRow


### PR DESCRIPTION
Change namespace to TestCases. Remove TestFixture attribute and constructor method of abstract BaseTestXXX class.