### PR TITLE
Fix XSSFDataValidationHelper.CreateValidation to use all CellRangeAddresses.

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFDataValidationHelper.cs
+++ b/ooxml/XSSF/UserModel/XSSFDataValidationHelper.cs
@@ -183,7 +183,7 @@ namespace NPOI.XSSF.UserModel
                 if(sqref.Length==0)
                     sqref = cellRangeAddress.FormatAsString();
                 else
-                    sqref = " " + cellRangeAddress.FormatAsString();
+                    sqref += " " + cellRangeAddress.FormatAsString();
             }
             newDataValidation.sqref = sqref;
             newDataValidation.allowBlank = (true);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
@@ -345,6 +345,33 @@ namespace TestCases.XSSF.UserModel
             }
         }
 
+        [Test]
+        public void TestCreateMultipleRegionsValidation()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            try
+            {
+                XSSFSheet sheet = wb.CreateSheet() as XSSFSheet;
+                IDataValidationHelper dataValidationHelper = sheet.GetDataValidationHelper();
+                IDataValidationConstraint constraint = dataValidationHelper.CreateExplicitListConstraint(new string[] { "A" });
+                CellRangeAddressList cellRangeAddressList = new CellRangeAddressList();
+                cellRangeAddressList.AddCellRangeAddress(0, 0, 0, 0);
+                cellRangeAddressList.AddCellRangeAddress(0, 1, 0, 1);
+                cellRangeAddressList.AddCellRangeAddress(0, 2, 0, 2);
+                XSSFDataValidation dataValidation = dataValidationHelper.CreateValidation(constraint, cellRangeAddressList) as XSSFDataValidation;
+                sheet.AddValidationData(dataValidation);
+
+                Assert.AreEqual(new CellRangeAddress(0, 0, 0, 0), sheet.GetDataValidations()[0].Regions.CellRangeAddresses[0]);
+                Assert.AreEqual(new CellRangeAddress(0, 0, 1, 1), sheet.GetDataValidations()[0].Regions.CellRangeAddresses[1]);
+                Assert.AreEqual(new CellRangeAddress(0, 0, 2, 2), sheet.GetDataValidations()[0].Regions.CellRangeAddresses[2]);
+                Assert.AreEqual("A1 B1 C1", dataValidation.GetCTDataValidation().sqref);
+            }
+            finally
+            {
+                wb.Close();
+            }
+        }
+
         private XSSFDataValidation CreateValidation(XSSFSheet sheet)
         {
             //create the cell that will have the validation applied


### PR DESCRIPTION
Multiple CellRangeAddresses can be used for XSSFDataValidation.CreateValidation, but only the last one is used.