### PR TITLE
improve performance of CreateRow for bigger excel sheets

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -720,18 +720,24 @@ namespace NPOI.XSSF.UserModel
             int i = keys.Count;
             return keys[keys.Count - 1];
         }
-        SortedList<int, XSSFRow> HeadMap(SortedList<int, XSSFRow> rows, int rownum)
+
+        int HeadMapCount(SortedList<int, XSSFRow> rows, int rownum)
         {
-            SortedList<int, XSSFRow> headmap = new SortedList<int, XSSFRow>();
+            int count = 0;
             foreach (int key in rows.Keys)
             {
                 if (key < rownum)
                 {
-                    headmap.Add(key, rows[key]);
+                    count++;
+                }
+                else
+                {
+                    break;
                 }
             }
-            return headmap;
+            return count;
         }
+
         /**
          * Create a new row within the sheet and return the high level representation
          *
@@ -768,7 +774,7 @@ namespace NPOI.XSSF.UserModel
                 {
                     // get number of rows where row index < rownum
                     // --> this tells us where our row should go
-                    int idx = HeadMap(_rows, rownum).Count;
+                    int idx = HeadMapCount(_rows, rownum);
                     ctRow = worksheet.sheetData.InsertNewRow(idx);
                 }
             }

--- a/solution/NPOI.sln
+++ b/solution/NPOI.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.OpenXml4Net", "..\open
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.OpenXmlFormats", "..\OpenXmlFormats\NPOI.OpenXmlFormats.csproj", "{A6874784-2875-4F40-9E8F-8385A640F5D6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.OOXML.TestCases", "..\testcases\ooxml\NPOI.OOXML.TestCases.csproj", "{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		.net 2 Release|Any CPU = .net 2 Release|Any CPU
@@ -61,6 +63,16 @@ Global
 		{A6874784-2875-4F40-9E8F-8385A640F5D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6874784-2875-4F40-9E8F-8385A640F5D6}.Release|Any CPU.ActiveCfg = .net 4 Release|Any CPU
 		{A6874784-2875-4F40-9E8F-8385A640F5D6}.Release|Any CPU.Build.0 = .net 4 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 2 Release|Any CPU.ActiveCfg = .net 2 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 2 Release|Any CPU.Build.0 = .net 2 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4 Release|Any CPU.ActiveCfg = .net 4 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4 Release|Any CPU.Build.0 = .net 4 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4.5 release|Any CPU.ActiveCfg = .net 4 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4.5 release|Any CPU.Build.0 = .net 4 Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/solution/NPOI.sln
+++ b/solution/NPOI.sln
@@ -12,8 +12,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.OpenXml4Net", "..\open
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.OpenXmlFormats", "..\OpenXmlFormats\NPOI.OpenXmlFormats.csproj", "{A6874784-2875-4F40-9E8F-8385A640F5D6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.OOXML.TestCases", "..\testcases\ooxml\NPOI.OOXML.TestCases.csproj", "{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		.net 2 Release|Any CPU = .net 2 Release|Any CPU
@@ -63,16 +61,6 @@ Global
 		{A6874784-2875-4F40-9E8F-8385A640F5D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6874784-2875-4F40-9E8F-8385A640F5D6}.Release|Any CPU.ActiveCfg = .net 4 Release|Any CPU
 		{A6874784-2875-4F40-9E8F-8385A640F5D6}.Release|Any CPU.Build.0 = .net 4 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 2 Release|Any CPU.ActiveCfg = .net 2 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 2 Release|Any CPU.Build.0 = .net 2 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4 Release|Any CPU.ActiveCfg = .net 4 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4 Release|Any CPU.Build.0 = .net 4 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4.5 release|Any CPU.ActiveCfg = .net 4 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}..net 4.5 release|Any CPU.Build.0 = .net 4 Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0BF8C464-8779-43CF-AD7A-B1109A86EAAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
CreateRow in the XSSFSheet is slow when you want to insert a lot of rows in the middle of a spreadsheet.

I profiled a test and figured out that "HeadMap" is creating a full copy of the elements, but in the end only the number is needed

![image](https://user-images.githubusercontent.com/723313/79989953-bdb3a900-84b0-11ea-81b5-b63f684eb0ee.png)

Since I found no other usage of that method I replaced it with a version that only counts and my test was running in about 2s, before it took 8s.

Also memory usage should be a little bit better.
