### PR TITLE
Bug found in LocaleUtil.cs. 

### DIFF
--- a/main/SS/UserModel/DateUtil.cs
+++ b/main/SS/UserModel/DateUtil.cs
@@ -257,6 +257,12 @@ namespace NPOI.SS.UserModel
             return GetJavaDate(date, false, tz, false);
         }
 
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static DateTime GetJavaDate(double date, TimeZone tz)
+        {
+            return GetJavaDate(date, false, tz, false);
+        }
+
         /**
          *  Given an Excel date with either 1900 or 1904 date windowing,
          *  Converts it to a Date.
@@ -278,7 +284,7 @@ namespace NPOI.SS.UserModel
          */
         public static DateTime GetJavaDate(double date, bool use1904windowing)
         {
-            return GetJavaCalendar(date, use1904windowing, null, false);
+            return GetJavaCalendar(date, use1904windowing, (TimeZoneInfo)null, false);
         }
         /**
          *  Given an Excel date with either 1900 or 1904 date windowing,
@@ -312,10 +318,52 @@ namespace NPOI.SS.UserModel
          *  @param tz The TimeZone to evaluate the date in
          *  @param use1904windowing  true if date uses 1904 windowing,
          *   or false if using 1900 date windowing.
+         *  @return Java representation of the date, or null if date is not a valid Excel date
+         */
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZone tz)
+        {
+            return GetJavaCalendar(date, use1904windowing, tz, false);
+        }
+        /**
+         *  Given an Excel date with either 1900 or 1904 date windowing,
+         *  converts it to a java.util.Date.
+         *  
+         *  Excel Dates and Times are stored without any timezone 
+         *  information. If you know (through other means) that your file 
+         *  uses a different TimeZone to the system default, you can use
+         *  this version of the getJavaDate() method to handle it.
+         *   
+         *  @param date  The Excel date.
+         *  @param tz The TimeZone to evaluate the date in
+         *  @param use1904windowing  true if date uses 1904 windowing,
+         *   or false if using 1900 date windowing.
          *  @param roundSeconds round to closest second
          *  @return Java representation of the date, or null if date is not a valid Excel date
          */
         public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZoneInfo tz, bool roundSeconds)
+        {
+            return GetJavaCalendar(date, use1904windowing, tz, roundSeconds);
+        }
+
+        /**
+         *  Given an Excel date with either 1900 or 1904 date windowing,
+         *  converts it to a java.util.Date.
+         *  
+         *  Excel Dates and Times are stored without any timezone 
+         *  information. If you know (through other means) that your file 
+         *  uses a different TimeZone to the system default, you can use
+         *  this version of the getJavaDate() method to handle it.
+         *   
+         *  @param date  The Excel date.
+         *  @param tz The TimeZone to evaluate the date in
+         *  @param use1904windowing  true if date uses 1904 windowing,
+         *   or false if using 1900 date windowing.
+         *  @param roundSeconds round to closest second
+         *  @return Java representation of the date, or null if date is not a valid Excel date
+         */
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZone tz, bool roundSeconds)
         {
             return GetJavaCalendar(date, use1904windowing, tz, roundSeconds);
         }
@@ -366,7 +414,7 @@ namespace NPOI.SS.UserModel
 
         public static DateTime GetJavaCalendarUTC(double date, bool use1904windowing)
         {
-            DateTime dt = GetJavaCalendar(date, use1904windowing, null, false);
+            DateTime dt = GetJavaCalendar(date, use1904windowing, (TimeZoneInfo)null, false);
             // Not exactly sure, if this 
             return TimeZoneInfo.ConvertTimeToUtc(dt);
             //or this is better:
@@ -387,6 +435,42 @@ namespace NPOI.SS.UserModel
         /// <param name="roundSeconds"></param>
         /// <returns>null if date is not a valid Excel date</returns>
         public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZoneInfo timeZone, bool roundSeconds)
+        {
+            if (!IsValidExcelDate(date))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Invalid Excel date double value: {0}", date));
+            }
+            int wholeDays = (int)Math.Floor(date);
+            int millisecondsInDay = (int)((date - wholeDays) * DAY_MILLISECONDS + 0.5);
+            DateTime calendar;
+            if (timeZone != null)
+            {
+                calendar = LocaleUtil.GetLocaleCalendar(timeZone);
+            }
+            else
+            {
+                calendar = LocaleUtil.GetLocaleCalendar(); // using default time-zone
+            }
+            //calendar = DateTime.Now;     // using default time-zone
+            SetCalendar(ref calendar, wholeDays, millisecondsInDay, use1904windowing, roundSeconds);
+            return calendar;
+        }
+
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZone timeZone)
+        {
+            return GetJavaCalendar(date, use1904windowing, timeZone, false);
+        }
+        /// <summary>
+        /// Get EXCEL date as Java Calendar (with default time zone). This is like GetJavaDate(double, boolean) but returns a Calendar object.
+        /// </summary>
+        /// <param name="date">The Excel date.</param>
+        /// <param name="use1904windowing">true if date uses 1904 windowing, or false if using 1900 date windowing.</param>
+        /// <param name="timeZone"></param>
+        /// <param name="roundSeconds"></param>
+        /// <returns>null if date is not a valid Excel date</returns>
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZone timeZone, bool roundSeconds)
         {
             if (!IsValidExcelDate(date))
             {

--- a/main/SS/UserModel/DateUtil.cs
+++ b/main/SS/UserModel/DateUtil.cs
@@ -252,7 +252,7 @@ namespace NPOI.SS.UserModel
         {
             return GetJavaDate(date, false);
         }
-        public static DateTime GetJavaDate(double date, TimeZone tz)
+        public static DateTime GetJavaDate(double date, TimeZoneInfo tz)
         {
             return GetJavaDate(date, false, tz, false);
         }
@@ -295,7 +295,7 @@ namespace NPOI.SS.UserModel
          *   or false if using 1900 date windowing.
          *  @return Java representation of the date, or null if date is not a valid Excel date
          */
-        public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZone tz)
+        public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZoneInfo tz)
         {
             return GetJavaCalendar(date, use1904windowing, tz, false);
         }
@@ -315,7 +315,7 @@ namespace NPOI.SS.UserModel
          *  @param roundSeconds round to closest second
          *  @return Java representation of the date, or null if date is not a valid Excel date
          */
-        public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZone tz, bool roundSeconds)
+        public static DateTime GetJavaDate(double date, bool use1904windowing, TimeZoneInfo tz, bool roundSeconds)
         {
             return GetJavaCalendar(date, use1904windowing, tz, roundSeconds);
         }
@@ -348,7 +348,7 @@ namespace NPOI.SS.UserModel
 
         public static DateTime GetJavaCalendar(double date)
         {
-            return GetJavaCalendar(date, false, (TimeZone)null, false);
+            return GetJavaCalendar(date, false, (TimeZoneInfo)null, false);
         }
 
         /**
@@ -361,16 +361,20 @@ namespace NPOI.SS.UserModel
          */
         public static DateTime GetJavaCalendar(double date, bool use1904windowing)
         {
-            return GetJavaCalendar(date, use1904windowing, (TimeZone)null, false);
+            return GetJavaCalendar(date, use1904windowing, (TimeZoneInfo)null, false);
         }
 
         public static DateTime GetJavaCalendarUTC(double date, bool use1904windowing)
         {
             DateTime dt = GetJavaCalendar(date, use1904windowing, null, false);
-            return TimeZone.CurrentTimeZone.ToUniversalTime(dt);
+            // Not exactly sure, if this 
+            return TimeZoneInfo.ConvertTimeToUtc(dt);
+            //or this is better:
+            return TimeZoneInfo.ConvertTimeToUtc(dt, TimeZoneInfo.Local);
+            // -- 
         }
 
-        public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZone timeZone)
+        public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZoneInfo timeZone)
         {
             return GetJavaCalendar(date, use1904windowing, timeZone, false);
         }
@@ -382,7 +386,7 @@ namespace NPOI.SS.UserModel
         /// <param name="timeZone"></param>
         /// <param name="roundSeconds"></param>
         /// <returns>null if date is not a valid Excel date</returns>
-        public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZone timeZone, bool roundSeconds)
+        public static DateTime GetJavaCalendar(double date, bool use1904windowing, TimeZoneInfo timeZone, bool roundSeconds)
         {
             if (!IsValidExcelDate(date))
             {

--- a/main/Util/LocaleUtil.cs
+++ b/main/Util/LocaleUtil.cs
@@ -22,8 +22,7 @@ namespace NPOI.Util
     {
         static LocaleUtil()
         {
-            userTimeZone = new ThreadLocal<TimeZone>();
-            userTimeZone.Value = TimeZone.CurrentTimeZone;
+            userTimeZone = new ThreadLocal<TimeZoneInfo>(()=>TimeZoneInfo.Local);
         }
         /**
          * Excel doesn't store TimeZone information in the file, so if in doubt,
@@ -38,9 +37,9 @@ namespace NPOI.Util
          */
         public static string CHARSET_1252 = CodePageUtil.CodepageToEncoding(CodePageUtil.CP_WINDOWS_1252);// ("CP1252");
 
-        private static ThreadLocal<TimeZone> userTimeZone;
+        private static ThreadLocal<TimeZoneInfo> userTimeZone;
 
-        private static ThreadLocal<CultureInfo> userLocale = new ThreadLocal<CultureInfo>();
+        private static ThreadLocal<CultureInfo> userLocale = new ThreadLocal<CultureInfo>(()=>CultureInfo.CurrentCulture);
         //private static ThreadLocal<Locale> userLocale = new ThreadLocal<Locale>();
 
         /**
@@ -50,7 +49,7 @@ namespace NPOI.Util
          *
          * @param timezone the timezone under which date calculations take place
          */
-        public static void SetUserTimeZone(TimeZone timezone)
+        public static void SetUserTimeZone(TimeZoneInfo timezone)
         {
             userTimeZone.Value = (timezone);
         }
@@ -58,7 +57,7 @@ namespace NPOI.Util
         /**
          * @return the time zone which is used for date calculations, defaults to UTC
          */
-        public static TimeZone GetUserTimeZone()
+        public static TimeZoneInfo GetUserTimeZone()
         {
             return userTimeZone.Value;
         }
@@ -137,9 +136,9 @@ namespace NPOI.Util
         /**
          * @return a calendar for the user locale and time zone
          */
-        public static DateTime GetLocaleCalendar(TimeZone timeZone)
+        public static DateTime GetLocaleCalendar(TimeZoneInfo timeZone)
         {
-            return timeZone.ToLocalTime(DateTime.Now);
+            return TimeZoneInfo.ConvertTime(DateTime.Now, timeZone);
             //return Calendar.GetInstance(timeZone, GetUserLocale());
         }
     }

--- a/main/Util/LocaleUtil.cs
+++ b/main/Util/LocaleUtil.cs
@@ -81,6 +81,7 @@ namespace NPOI.Util
         /**
          * @return the time zone which is used for date calculations, defaults to UTC
          */
+        [Obsolete("The class TimeZone was marked obsolete, Use GetUserTimeZoneInfo instead.")]
         public static TimeZone GetUserTimeZone()
         {
             return obsUserTimeZone.Value;

--- a/main/Util/LocaleUtil.cs
+++ b/main/Util/LocaleUtil.cs
@@ -23,6 +23,7 @@ namespace NPOI.Util
         static LocaleUtil()
         {
             userTimeZone = new ThreadLocal<TimeZoneInfo>(()=>TimeZoneInfo.Local);
+            obsUserTimeZone = new ThreadLocal<TimeZone>(() => TimeZone.CurrentTimeZone);
         }
         /**
          * Excel doesn't store TimeZone information in the file, so if in doubt,
@@ -38,6 +39,8 @@ namespace NPOI.Util
         public static string CHARSET_1252 = CodePageUtil.CodepageToEncoding(CodePageUtil.CP_WINDOWS_1252);// ("CP1252");
 
         private static ThreadLocal<TimeZoneInfo> userTimeZone;
+
+        private static ThreadLocal<TimeZone> obsUserTimeZone;
 
         private static ThreadLocal<CultureInfo> userLocale = new ThreadLocal<CultureInfo>(()=>CultureInfo.CurrentCulture);
         //private static ThreadLocal<Locale> userLocale = new ThreadLocal<Locale>();
@@ -55,11 +58,32 @@ namespace NPOI.Util
         }
 
         /**
+         * As time zone information is not stored in any format, it can be
+         * set before any date calculations take place.
+         * This setting is specific to the current thread.
+         *
+         * @param timezone the timezone under which date calculations take place
+         */
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static void SetUserTimeZone(TimeZone timezone)
+        {
+            obsUserTimeZone.Value = (timezone);
+        }
+
+        /**
          * @return the time zone which is used for date calculations, defaults to UTC
          */
-        public static TimeZoneInfo GetUserTimeZone()
+        public static TimeZoneInfo GetUserTimeZoneInfo()
         {
             return userTimeZone.Value;
+        }
+
+        /**
+         * @return the time zone which is used for date calculations, defaults to UTC
+         */
+        public static TimeZone GetUserTimeZone()
+        {
+            return obsUserTimeZone.Value;
         }
 
         /**
@@ -84,7 +108,7 @@ namespace NPOI.Util
          */
         public static DateTime GetLocaleCalendar()
         {
-            return GetLocaleCalendar(GetUserTimeZone());
+            return GetLocaleCalendar(GetUserTimeZoneInfo());
         }
 
         /**
@@ -139,6 +163,16 @@ namespace NPOI.Util
         public static DateTime GetLocaleCalendar(TimeZoneInfo timeZone)
         {
             return TimeZoneInfo.ConvertTime(DateTime.Now, timeZone);
+            //return Calendar.GetInstance(timeZone, GetUserLocale());
+        }
+
+        /**
+         * @return a calendar for the user locale and time zone
+         */
+        [Obsolete("The class TimeZone was marked obsolete, Use the Overload using TimeZoneInfo instead.")]
+        public static DateTime GetLocaleCalendar(TimeZone timeZone)
+        {
+            return timeZone.ToLocalTime(DateTime.Now);
             //return Calendar.GetInstance(timeZone, GetUserLocale());
         }
     }


### PR DESCRIPTION
Hi, I found a bug in LocaleUtil.cs, which leads to a NullReferenceException in multi-threaded environments.
Since the TimeZone class is marked obsolete, i also changed all references to this class to TimeZoneInfo.
The original Methods are left intact, but all marked obsolete.