### PR TITLE
fix: Rich strings hash for texts with the color set as RGB

### DIFF
--- a/OpenXmlFormats/Spreadsheet/SharedString/CT_Rst.cs
+++ b/OpenXmlFormats/Spreadsheet/SharedString/CT_Rst.cs
@@ -134,6 +134,10 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                                 {
                                     sw.Write("<color theme=\"" + r.rPr.color.theme + "\"/>");
                                 }
+                                if (r.rPr.color != null && r.rPr.color.rgbSpecified)
+                                {
+                                    sw.Write("<color rgb=\"" + BitConverter.ToString(r.rPr.color.rgb).Replace("-", string.Empty) + "\"/>");
+                                }
                                 if (r.rPr.rFont != null)
                                 {
                                     sw.Write("<rFont val=\"" + r.rPr.rFont.val + "\"/>");

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFRichTextString.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFRichTextString.cs
@@ -22,6 +22,8 @@ using NPOI.XSSF.Model;
 using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 using System;
+using System.Drawing;
+
 namespace TestCases.XSSF.UserModel
 {
     /**
@@ -246,6 +248,22 @@ namespace TestCases.XSSF.UserModel
             //Assert.AreEqual("<xml-fragment xml:space=\"preserve\">  Apache</t>", rt.GetCTRst().GetRArray(0).xmlText());
             //Assert.AreEqual("<xml-fragment xml:space=\"preserve\"> POI</xml-fragment>", rt.getCTRst().getRArray(1).xgetT().xmlText());
             //Assert.AreEqual("<xml-fragment xml:space=\"preserve\"> </xml-fragment>", rt.getCTRst().getRArray(2).xgetT().xmlText());
+        }
+
+        /**
+         * Ensure that strings with the color set as RGB are treated differently when the color is different.
+         */
+        [Test]
+        public void TestRgbColor()
+        {
+            const string testText = "Apache";
+            XSSFRichTextString rt = new XSSFRichTextString(testText);
+            XSSFFont font = new XSSFFont { FontName = "Times New Roman", FontHeightInPoints = 11 };
+            font.SetColor(new XSSFColor(Color.Red));
+            rt.ApplyFont(0, testText.Length, font);
+            CT_Rst ct = rt.GetCTRst();
+
+            Assert.AreEqual("<r><rPr><color rgb=\"FF0000\"/><rFont val=\"Times New Roman\"/><sz val=\"11\"/></rPr><t>Apache</t></r>", ct.XmlText);
         }
 
         /**


### PR DESCRIPTION
Fixed shared string hash for texts with the color set as RGB so they are considered different strings if the color is different. This fixes the issue mentioned in #211 .