### PR TITLE
Update SixLabors to fix Security Vuln

### DIFF
--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">


### PR DESCRIPTION
This fixes issues raised in Snyk and on nuget.org https://www.nuget.org/packages/SixLabors.ImageSharp